### PR TITLE
Modal component 구현 & 로그인 버튼 클릭시 modal 출력

### DIFF
--- a/cocode/package.json
+++ b/cocode/package.json
@@ -74,5 +74,14 @@
 		"style-loader": "^1.0.0",
 		"webpack-cli": "^3.3.10",
 		"webpack-dev-server": "^3.9.0"
+	},
+	"jest": {
+		"moduleDirectories": [
+			"node_modules",
+			"src"
+		],
+		"moduleNameMapper": {
+			"\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test_setup/__mocks__/fileMock.js"
+		}
 	}
 }

--- a/cocode/public/index.html
+++ b/cocode/public/index.html
@@ -10,6 +10,7 @@
 	</head>
 	<body>
 		<div id="root"></div>
+		<div id="modal"></div>
 		<script src="./bundle.js"></script>
 	</body>
 </html>

--- a/cocode/src/components/CloseButton/close.svg
+++ b/cocode/src/components/CloseButton/close.svg
@@ -1,0 +1,7 @@
+<svg width="15px" height="15px" viewBox="0 0 15 15" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Artboard" transform="translate(1.000000, 1.000000)"></g>
+        <path d="M1,1 L14,14" id="Path" stroke="#AFAFAF" stroke-width="3"></path>
+        <path d="M14,1 L1,14" id="Path-2" stroke="#AFAFAF" stroke-width="3"></path>
+    </g>
+</svg>

--- a/cocode/src/components/CloseButton/index.js
+++ b/cocode/src/components/CloseButton/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import close from './close.svg';
+
+function CloseButton({ onClick }) {
+	return (
+		<button onClick={onClick}>
+			<img src={close} />
+		</button>
+	);
+}
+
+export default CloseButton;

--- a/cocode/src/components/GlobalStyle/index.js
+++ b/cocode/src/components/GlobalStyle/index.js
@@ -16,6 +16,10 @@ const GlobalStyle = createGlobalStyle`
         width: 100%;
         font-size: 16px;
     }
+
+    button {
+        cursor: pointer;
+    }
 `;
 
 export default GlobalStyle;

--- a/cocode/src/components/LoginModalBody/index.js
+++ b/cocode/src/components/LoginModalBody/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import * as Styled from './style';
+
+function LoginModalBody({ onClickLoginButton }) {
+	return (
+		<Styled.LoginModalBody>
+			<Styled.LoginModalBodyTitle>Sign In</Styled.LoginModalBodyTitle>
+			<Styled.LoginModalBodyButton onClick={onClickLoginButton}>
+				Sign In With GitHub
+			</Styled.LoginModalBodyButton>
+		</Styled.LoginModalBody>
+	);
+}
+
+export default LoginModalBody;

--- a/cocode/src/components/LoginModalBody/style.js
+++ b/cocode/src/components/LoginModalBody/style.js
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+const LoginModalBody = styled.div`
+	& {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+
+		width: 25rem;
+	}
+`;
+
+const LoginModalBodyTitle = styled.h1`
+	& {
+		text-align: center;
+		font-size: 3rem;
+	}
+`;
+
+const LoginModalBodyButton = styled.button`
+	& {
+		margin: 3rem 0 1.5rem 0;
+		padding: 0.5rem 1.5rem;
+
+		font-size: 1.25rem;
+
+		color: white;
+		background-color: black;
+		border-radius: 0.5rem;
+	}
+`;
+
+export { LoginModalBody, LoginModalBodyTitle, LoginModalBodyButton };

--- a/cocode/src/components/Modal/index.js
+++ b/cocode/src/components/Modal/index.js
@@ -6,7 +6,7 @@ import CloseButton from 'components/CloseButton';
 function Modal({ modalBody, onClose }) {
 	return (
 		<Styled.ModalBackGround>
-			<Styled.Modal>
+			<Styled.Modal role="dialog">
 				<Styled.ModalHeader>
 					<CloseButton onClick={onClose} />
 				</Styled.ModalHeader>

--- a/cocode/src/components/Modal/index.js
+++ b/cocode/src/components/Modal/index.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import * as Styled from './style';
+
+import CloseButton from 'components/CloseButton';
+
+function Modal({ modalBody, onClose }) {
+	return (
+		<Styled.ModalBackGround>
+			<Styled.Modal>
+				<Styled.ModalHeader>
+					<CloseButton onClick={onClose} />
+				</Styled.ModalHeader>
+				<Styled.ModalBody>{modalBody}</Styled.ModalBody>
+			</Styled.Modal>
+		</Styled.ModalBackGround>
+	);
+}
+
+export default Modal;

--- a/cocode/src/components/Modal/style.js
+++ b/cocode/src/components/Modal/style.js
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+
+const ModalBackGround = styled.div`
+	& {
+		position: fixed;
+		top: 0;
+		left: 0;
+
+		display: flex;
+		align-items: center;
+
+		width: 100%;
+		height: 100%;
+
+		background-color: rgba(0, 0, 0, 0.3);
+	}
+`;
+
+const Modal = styled.dialog`
+	& {
+		display: flex;
+		flex-direction: column;
+		flex-wrap: wrap;
+
+		margin: auto;
+
+		height: auto;
+
+		background-color: white;
+	}
+`;
+
+const ModalHeader = styled.header`
+	& {
+		padding: 1rem;
+
+		display: flex;
+		flex-direction: row;
+		justify-content: flex-end;
+		align-items: flex-end;
+	}
+`;
+
+const ModalBody = styled.section``;
+
+export { ModalBackGround, Modal, ModalHeader, ModalBody };

--- a/cocode/src/components/Modal/test.js
+++ b/cocode/src/components/Modal/test.js
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import Modal from '.';
+
+/*
+
+@ modal behavior test List
+
+#1 열기 버튼을 클릭하면 모달이 열린다.
+#2 닫기 버튼을 클릭하면 모달이 닫힌다.
+
+*/
+
+const MODAL_OPEN_BUTTON_TEXT = 'modal open button';
+const MODAL_ROLE = 'dialog';
+
+afterEach(cleanup);
+
+describe('Modal behavior test', () => {
+	it('#1 열기 버튼을 클릭하면 모달이 열린다.', openModalTest);
+	it('#2 닫기 버튼을 클릭하면 모달이 닫힌다.', closeModalTest);
+});
+
+function MockModal() {
+	const [isOpen, setIsOpen] = useState(false);
+	const handleOpenModal = () => setIsOpen(true);
+	const onClose = () => setIsOpen(true);
+
+	return (
+		<div>
+			<button onClick={handleOpenModal}>{MODAL_OPEN_BUTTON_TEXT}</button>
+			{isOpen && <Modal modalBody={''} onClose={onClose} />}
+		</div>
+	);
+}
+
+function openModalTest() {
+	// given
+	const { getByText, getByRole } = render(<MockModal />);
+	const openButton = getByText(MODAL_OPEN_BUTTON_TEXT);
+
+	// when
+	fireEvent.click(openButton);
+
+	// then
+	const modal = getByRole(MODAL_ROLE);
+	expect(modal).toBeTruthy();
+}
+
+function closeModalTest() {
+	// given
+	const { getByText, getByRole, getAllByRole } = render(<MockModal />);
+	const openButton = getByText(MODAL_OPEN_BUTTON_TEXT);
+	fireEvent.click(openButton);
+
+	const closeButton = getAllByRole('button')[1];
+
+	// when
+	fireEvent.click(closeButton);
+
+	// then
+	expect(!getByRole(MODAL_ROLE));
+}

--- a/cocode/src/components/ModalPortal/index.js
+++ b/cocode/src/components/ModalPortal/index.js
@@ -1,0 +1,8 @@
+import ReactDOM from 'react-dom';
+
+const ModalPortal = ({ children }) => {
+	const modalElement = document.getElementById('modal');
+	return ReactDOM.createPortal(children, modalElement);
+};
+
+export default ModalPortal;

--- a/cocode/src/containers/Header/index.js
+++ b/cocode/src/containers/Header/index.js
@@ -1,9 +1,17 @@
-import React from 'react';
+import React, { useState } from 'react';
 import * as Styled from './style';
 import Logo from 'components/Logo';
 import { Grid } from '@material-ui/core';
 
+import ModalPortal from 'components/ModalPortal';
+import Modal from 'components/Modal';
+import LoginModalBody from 'components/LoginModalBody';
+
 function Header() {
+	const [isSignInModalOpen, setIsSignInModalOpen] = useState(false);
+	const handleOpenSignInModal = () => setIsSignInModalOpen(true);
+	const handleCloseSignInModal = () => setIsSignInModalOpen(false);
+
 	return (
 		<Styled.Header>
 			<Grid
@@ -16,9 +24,19 @@ function Header() {
 					<Logo />
 				</Grid>
 				<Grid item xs={1} className="Header-text-right">
-					<Styled.SignInButton>Sign In</Styled.SignInButton>
+					<Styled.SignInButton onClick={handleOpenSignInModal}>
+						Sign In
+					</Styled.SignInButton>
 				</Grid>
 			</Grid>
+			{isSignInModalOpen && (
+				<ModalPortal>
+					<Modal
+						modalBody={<LoginModalBody />}
+						onClose={handleCloseSignInModal}
+					/>
+				</ModalPortal>
+			)}
 		</Styled.Header>
 	);
 }

--- a/cocode/src/containers/Header/test.js
+++ b/cocode/src/containers/Header/test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import Header from '.';
+
+/*
+
+@ Login modal behavior test List
+- SignIn 버튼을 클릭하면 로그인 모달이 출력된다.
+- 로그인 모달에서 오른쪽 상단의 닫기 버튼을 누르면 모달이 없어진다.
+
+*/
+
+const SIGN_IN_BUTTON_TEXT = 'Sign In';
+
+afterEach(cleanup);
+
+describe('Login modal behavior test', () => {
+	beforeAll(prepareForReactPortal);
+
+	it('#1 SignIn 버튼을 클릭하면 로그인 모달이 열린다.', openLoginModalTest);
+});
+
+function prepareForReactPortal() {
+	let modalElement = document.getElementById('modal');
+	if (!modalElement) {
+		modalElement = document.createElement('div');
+		modalElement.setAttribute('id', 'modal');
+		document.body.appendChild(modalElement);
+	}
+}
+
+function openLoginModalTest() {
+	// given
+	const { getByText, getByRole } = render(<Header />);
+	const signInButton = getByText(SIGN_IN_BUTTON_TEXT);
+
+	// when
+	fireEvent.click(signInButton);
+
+	// then
+	const loginModal = getByRole('dialog');
+	expect(loginModal).toBeTruthy();
+}

--- a/cocode/test_setup/__mocks__/fileMock.js
+++ b/cocode/test_setup/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';


### PR DESCRIPTION
## 간단한 요약 설명
- 공통으로 사용되는 modal component를 구현했습니다.
   - modal은 header와 body로 구분됩니다.
   - body는 유동적으로 들어갈 컴포넌트를 변경할 수 있습니다.
- 로그인 모달의 body를 구현했습니다.
   - 모달 안의 로그인 버튼으로 github 로그인을 요청할 수 있습니다.(추후에 추가)
- 헤더에서 SignIn 버튼을 클릭하면 로그인 모달이 출력되도록 구현했습니다.
- jest 실행 시 절대경로로 지정된 component를 읽어올 수 있도록 설정을 추가했습니다.

## 관련 이슈
* close #3 
* close #4 
