### PR TITLE
Project Tab Container 구현

### DIFF
--- a/cocode/src/constants/theme.js
+++ b/cocode/src/constants/theme.js
@@ -13,4 +13,17 @@ const BROWSER_THEME = {
 	browserHeignt: '88.8vh'
 };
 
-export { DEFAULT_THEME, BROWSER_THEME };
+const TAB_CONTAINER_THEME = {
+	tabContainerBGColor: '#0e0f10',
+	tabContainerTitleColor: '#7E7E7E',
+	tabContainerFileTextColor: '#878788',
+	tabContainerFileHoverTextColor: '#fff',
+	tabContainerFileHoverBGColor: '#2accf944',
+
+	tabContainerTitleSize: '1.25rem',
+	tabContainerFileTextSize: '1rem',
+
+	tabContainerTitleWeight: '600'
+};
+
+export { DEFAULT_THEME, BROWSER_THEME, TAB_CONTAINER_THEME };

--- a/cocode/src/containers/ProjectTab/index.js
+++ b/cocode/src/containers/ProjectTab/index.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import * as Styled from './style';
+
+const TabTitle = 'EXPLOLER';
+
+const mockData = [
+	{
+		type: 'folder',
+		src: 'https://codesandbox.io/static/media/folder.30a30d83.svg',
+		depth: 1,
+		name: 'public'
+	},
+	{
+		type: 'folder_open',
+		src: 'https://codesandbox.io/static/media/folder-open.df474ba4.svg',
+		depth: 1,
+		name: 'src'
+	},
+	{
+		type: 'javascript',
+		src:
+			'https://cdn.jsdelivr.net/gh/PKief/vscode-material-icon-theme@master/icons/javascript.svg',
+		depth: 2,
+		name: 'index.js'
+	}
+];
+
+function ProjectTab() {
+	return (
+		<Styled.ProjectTab>
+			<Styled.Title>{TabTitle}</Styled.Title>
+			{mockData.map(({ type, src, depth, name }, index) => {
+				return (
+					<Styled.File key={index} depth={depth}>
+						<Styled.Icon src={src} alt={type} />
+						<font>{name}</font>
+					</Styled.File>
+				);
+			})}
+		</Styled.ProjectTab>
+	);
+}
+
+export default ProjectTab;

--- a/cocode/src/containers/ProjectTab/style.js
+++ b/cocode/src/containers/ProjectTab/style.js
@@ -1,0 +1,58 @@
+import styled from 'styled-components';
+import { TAB_CONTAINER_THEME } from 'constants/theme';
+
+const ProjectTab = styled.section`
+	& {
+		width: 100%;
+		height: 100vh;
+
+		background-color: ${TAB_CONTAINER_THEME.tabContainerBGColor};
+	}
+`;
+
+const Title = styled.h1`
+	& {
+		padding: 0.7rem 1rem;
+
+		color: ${TAB_CONTAINER_THEME.tabContainerTitleColor};
+		font-size: ${TAB_CONTAINER_THEME.tabContainerTitleSize};
+		font-weight: ${TAB_CONTAINER_THEME.tabContainerTitleWeight};
+	}
+`;
+
+const Icon = styled.img`
+	& {
+		margin-right: 0.5rem;
+
+		width: ${TAB_CONTAINER_THEME.tabContainerFileTextSize};
+		height: ${TAB_CONTAINER_THEME.tabContainerFileTextSize};
+	}
+`;
+
+const File = styled.div`
+	& {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+
+		padding: 0.4rem;
+		padding-left: ${({ depth }) => `${depth}rem`};
+
+		cursor: pointer;
+
+		font {
+			font-size: ${TAB_CONTAINER_THEME.tabContainerFileTextSize};
+			color: ${TAB_CONTAINER_THEME.tabContainerFileTextColor};
+		}
+	}
+
+	&:hover {
+		background-color: ${TAB_CONTAINER_THEME.tabContainerFileHoverBGColor};
+
+		font {
+			color: ${TAB_CONTAINER_THEME.tabContainerFileHoverTextColor};
+		}
+	}
+`;
+
+export { ProjectTab, Title, Icon, File };


### PR DESCRIPTION
## 간단한 요약 설명
- Project Tab Container를 구현했습니다.
- 좌측의 Tab bar에서 Project item을 선택하면 출력되는 UI입니다.
- mock data를 가지고 프로젝트 목록을 출력해주었습니다.
- TabBar, Browser, Editor 같은 다른 컴포넌트 간의 통신은 고려하지 않고 틀만 구현된 상태입니다.

## 관련 이슈
close #25 
