### PR TITLE
프로젝트 페이지의 에디터 UI 구현

### DIFF
--- a/cocode/package.json
+++ b/cocode/package.json
@@ -39,6 +39,7 @@
 	"homepage": "https://github.com/connect-foundation/2019-04#readme",
 	"dependencies": {
 		"@material-ui/core": "^4.6.0",
+		"@monaco-editor/react": "^2.3.0",
 		"axios": "^0.19.0",
 		"dotenv": "^8.2.0",
 		"file-loader": "^4.2.0",

--- a/cocode/src/components/FileTab/index.js
+++ b/cocode/src/components/FileTab/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import * as Styled from './style';
+
+function FileTab({ index, FileName, icon, type, className, onClick }) {
+    const handleTabClick = () => onClick(index);
+
+    return (
+        <Styled.Tab onClick={handleTabClick} className={className}>
+            <Styled.Icon src={icon} alt={type} />
+            {FileName}
+        </Styled.Tab>
+    );
+}
+
+export default FileTab;

--- a/cocode/src/components/FileTab/style.js
+++ b/cocode/src/components/FileTab/style.js
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+
+//TODO 나중에 테마로 분리할 계획입니다.
+const EDITOR_DARK_COLOR = '#111518';
+
+const Tab = styled.li`
+    & {
+        padding: 0.8rem;
+        display: inline-flex;
+        background-color: ${EDITOR_DARK_COLOR};
+        font-size: 0.8rem;
+        cursor: pointer;
+    }
+    
+    &:after {
+        content: 'X';
+        font-weight: 800;
+        margin-left: 0.8rem;
+        visibility: hidden;
+    }
+    
+    &:hover {
+      &:after {
+        visibility: visible;
+      }
+    }
+`;
+
+const Icon = styled.img`
+    & {
+        width: 1.2rem;
+        height: 1.2rem;
+        margin-right: 0.3rem;
+    }
+`;
+
+export { Icon, Tab };

--- a/cocode/src/components/FileTabBar/index.js
+++ b/cocode/src/components/FileTabBar/index.js
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import * as Styled from './style';
+import FileTab from '../FileTab';
+
+const DEFAULT_OPENED_FILE_INDEX = 0;
+
+function FileTabBar() {
+    const [ clickedIndex, setClickedIndex ] = useState(DEFAULT_OPENED_FILE_INDEX);
+
+    const files = [
+		{
+			name: 'index.html',
+			type: 'html',
+			icon: 'https://cdn.jsdelivr.net/gh/PKief/vscode-material-icon-theme@master/icons/html.svg'
+		},
+		{
+			name: 'index.js',
+			type: 'js',
+			icon: 'https://cdn.jsdelivr.net/gh/PKief/vscode-material-icon-theme@master/icons/javascript.svg'
+		},
+		{
+			name: 'app.js',
+			type: 'js',
+			icon: 'https://cdn.jsdelivr.net/gh/PKief/vscode-material-icon-theme@master/icons/javascript.svg'
+		},
+		{
+			name: 'app.css',
+			type: 'css',
+			icon: 'https://cdn.jsdelivr.net/gh/PKief/vscode-material-icon-theme@master/icons/css.svg'
+		},
+	];
+
+    const handleSetClickedIndex = (index) => setClickedIndex(index);
+
+    return (
+		<Styled.TabBar>
+			{files.map(({ name, icon, type }, index) => {
+				return (
+					<FileTab
+						key={index}
+						index={index}
+						FileName={name}
+						icon={icon}
+						type={type}
+						className={index === clickedIndex ? 'clicked' : ''}
+						onClick={handleSetClickedIndex}
+					/>
+				);
+			})}
+		</Styled.TabBar>
+	);
+}
+
+export default FileTabBar;

--- a/cocode/src/components/FileTabBar/style.js
+++ b/cocode/src/components/FileTabBar/style.js
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+//TODO 나중에 테마로 분리할 계획입니다.
+const EDITOR_MAIN_COLOR = '#1E2022';
+
+const TabBar = styled.ul`
+    & {
+        width: 100%;
+        list-style: none;
+        display: inline-flex;
+        overflow: scroll;
+    }
+    
+    .clicked {
+        background-color: ${EDITOR_MAIN_COLOR};
+        
+        &:after {
+          visibility: visible;
+        }
+    }
+`;
+
+export { TabBar };

--- a/cocode/src/components/GlobalStyle/index.js
+++ b/cocode/src/components/GlobalStyle/index.js
@@ -1,6 +1,34 @@
 import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyle = createGlobalStyle`
+    ::-webkit-scrollbar {
+        width: 10px;
+        height: 5px
+    }
+    
+    ::-webkit-scrollbar-track {
+        background-color: transparent
+    }
+    
+    ::-webkit-scrollbar-thumb {
+        background-color: #2d2d2d;
+        border-radius: 5px
+    }
+    
+    ::-webkit-scrollbar-thumb:hover {
+        background: #4A4A4A
+    }
+    
+    ::-webkit-scrollbar-button:horizontal:decrement,
+    ::-webkit-scrollbar-button:horizontal:increment {
+        width: 0px;
+        height: 0px
+    }
+    
+    ::-webkit-scrollbar-corner {
+        background-color: transparent
+    }
+    
     * {
         font-family: 'Source Sans Pro', sans-serif;
         text-decoration: none;

--- a/cocode/src/components/MonacoEditor/index.js
+++ b/cocode/src/components/MonacoEditor/index.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { ControlledEditor } from '@monaco-editor/react';
+import * as Styled from './style';
+
+function MonacoEditor() {
+    return (
+        <Styled.MonacoEditor>
+            <ControlledEditor
+                height="100vh"
+                language="javascript"
+                theme="vs-dark"
+            />
+        </Styled.MonacoEditor>
+    );
+}
+
+export default MonacoEditor;

--- a/cocode/src/components/MonacoEditor/index.stories.js
+++ b/cocode/src/components/MonacoEditor/index.stories.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import MonacoEditor from '.';
+
+export default {
+    title: 'MonacoEditor'
+};
+
+function Editor() {
+    return <MonacoEditor />;
+}
+
+export { Editor };

--- a/cocode/src/components/MonacoEditor/style.js
+++ b/cocode/src/components/MonacoEditor/style.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+//TODO 나중에 테마로 분리할 계획입니다.
+const EDITOR_MAIN_COLOR = '#1E2022';
+const EDITOR_CURRENT_LINT_COLOR = '#2a2f32';
+
+const MonacoEditor = styled.div`
+    .monaco-editor-background, .margin {
+        background-color: ${EDITOR_MAIN_COLOR} !important;
+    }
+    
+    .scroll-decoration {
+        box-shadow: none !important;
+    }
+    
+    .monaco-editor .view-overlays .current-line {
+        border: ${EDITOR_CURRENT_LINT_COLOR};
+        background-color: ${EDITOR_CURRENT_LINT_COLOR};
+    }
+`;
+
+export { MonacoEditor };

--- a/cocode/src/containers/Editor/index.js
+++ b/cocode/src/containers/Editor/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import FileTabBar from 'components/FileTabBar';
+import MonacoEditor from 'components/MonacoEditor';
+
+function Editor() {
+    return (
+        <>
+            <FileTabBar />
+            <MonacoEditor />
+        </>
+    );
+}
+
+export default Editor;

--- a/cocode/yarn.lock
+++ b/cocode/yarn.lock
@@ -1444,6 +1444,11 @@
     prop-types "^15.7.2"
     react-is "^16.8.6"
 
+"@monaco-editor/react@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-2.3.0.tgz#ef1e09c408bb3119e2dc0d369b132e82b2d3ade7"
+  integrity sha512-jmmZCQ4iSMfwelWGRV4HWUOJchkN4MOx9vhx1DWvC6ERpvK5DXrcwJBBzuayVtiK7cyCVOGKB7mgjT7KOdUkJw==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
## 간단한 요약 설명
모나코 라이브러리를 사용해 에디터를 구현했습니다.
에디터 상단의 파일 탭 및 탭바를 구현했습니다.
다른 컴포넌트 간의 통신은 고려하지 않고 틀만 구현된 상태입니다.

## 관련 이슈
* close #26
* close #29
* ing #28