### PR TITLE
드롭다운 메뉴 작성

### DIFF
--- a/cocode/src/components/DropDownMenu/index.js
+++ b/cocode/src/components/DropDownMenu/index.js
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { useState } from 'react';
+import * as Styled from './style';
+
+function DropDownMenu({ children, menuItems, ...props }) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	const handleIsOpen = () => setIsOpen(!isOpen);
+	return (
+		<Styled.DropDownMenu {...props}>
+			{React.cloneElement(children, { onClick: handleIsOpen })}
+			{isOpen && (
+				<Styled.DropDownList>
+					{menuItems &&
+						menuItems.map(({ value, ...props }, key) => (
+							<Styled.DropDownItem {...props} key={key}>
+								{value}
+							</Styled.DropDownItem>
+						))}
+				</Styled.DropDownList>
+			)}
+		</Styled.DropDownMenu>
+	);
+}
+
+export default DropDownMenu;

--- a/cocode/src/components/DropDownMenu/index.stories.js
+++ b/cocode/src/components/DropDownMenu/index.stories.js
@@ -9,7 +9,6 @@ export default {
 const Box = styled.div`
 	display: flex;
 	flex-direction: row;
-	/* flex: 1; */
 `;
 
 const Button = styled.button`

--- a/cocode/src/components/DropDownMenu/index.stories.js
+++ b/cocode/src/components/DropDownMenu/index.stories.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import styled from 'styled-components';
+import DropDownMenu from '.';
+
+export default {
+	title: 'DropDownMenu'
+};
+
+const Box = styled.div`
+	display: flex;
+	flex-direction: row;
+	/* flex: 1; */
+`;
+
+const Button = styled.button`
+	padding: 2rem;
+	width: 10rem;
+	height: 4rem;
+	background-color: #5b5b5b;
+`;
+
+export const dropDownMenu = () => {
+	const menuItems = [
+		{
+			value: 'test1',
+			onClick: () => alert('test1')
+		},
+		{
+			value: 'test2',
+			onClick: () => alert('test2')
+		},
+		{
+			value: 'test3',
+			onClick: () => alert('test3')
+		},
+		{
+			value: 'test4',
+			onClick: () => alert('test4')
+		},
+		{
+			value: 'test5',
+			onClick: () => alert('test5')
+		}
+	];
+	return (
+		<Box>
+			<DropDownMenu menuItems={menuItems}>
+				<button>Test1</button>
+			</DropDownMenu>
+			<DropDownMenu menuItems={menuItems}>
+				<button>Test2</button>
+			</DropDownMenu>
+			<DropDownMenu menuItems={menuItems}>
+				<button>Test3</button>
+			</DropDownMenu>
+			<DropDownMenu menuItems={menuItems}>
+				<Button>custom button</Button>
+			</DropDownMenu>
+		</Box>
+	);
+};

--- a/cocode/src/components/DropDownMenu/style.js
+++ b/cocode/src/components/DropDownMenu/style.js
@@ -1,5 +1,9 @@
 import styled from 'styled-components';
 
+const BUTTON_COLOR = '#2b2b2b';
+const BUTTON_COLOR_HOVER = '#4b4b4b';
+const BUTTON_BOUNDARY = '#383838';
+
 const DropDownMenu = styled.div`
 	& {
 		display: flex;
@@ -30,17 +34,16 @@ const DropDownItem = styled.button`
 		z-index: 1;
 
 		font-size: 1.5rem;
-		color: ${({ theme }) => theme.textColor};
 		vertical-align: center;
 		text-align: right;
 
-		background-color: #2b2b2b;
+		background-color: ${BUTTON_COLOR};
 
 		border: none;
-		border-top: solid #383838;
+		border-top: solid ${BUTTON_BOUNDARY};
 	}
 	&:hover {
-		background-color: #4b4b4b;
+		background-color: ${BUTTON_COLOR_HOVER};
 		cursor: pointer;
 	}
 `;

--- a/cocode/src/components/DropDownMenu/style.js
+++ b/cocode/src/components/DropDownMenu/style.js
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+
+const DropDownMenu = styled.div`
+	& {
+		display: flex;
+		justify-content: flex-end;
+
+		position: relative;
+	}
+`;
+
+const DropDownList = styled.ul`
+	& {
+		display: flex;
+		flex-direction: column;
+
+		position: absolute;
+
+		top: 100%;
+		padding: 0;
+		margin: 0;
+	}
+`;
+
+const DropDownItem = styled.button`
+	& {
+		height: 2.5rem;
+		width: 8rem;
+		padding: 0.25rem 1rem;
+		z-index: 1;
+
+		font-size: 1.5rem;
+		color: ${({ theme }) => theme.textColor};
+		vertical-align: center;
+		text-align: right;
+
+		background-color: #2b2b2b;
+
+		border: none;
+		border-top: solid #383838;
+	}
+	&:hover {
+		background-color: #4b4b4b;
+		cursor: pointer;
+	}
+`;
+
+export { DropDownMenu, DropDownList, DropDownItem };


### PR DESCRIPTION
## 간단한 요약 설명
드롭다운 메뉴를 작성하였습니다.

드롭다운 메뉴 사용 시 사용자에게 보이는 버튼은 어떤 버튼이든 사용할 수 있도록 태그 사이에 버튼을 받도록 하였습니다. 
드롭다운 메뉴의 정보는 객체 배열을 넘겨 사용할 수 있도록 했습니다.

```javascript
const menuItems = [
		{
			value: '메뉴 아이템 제목1',
			onClick: ... function,
                        ... element props
		},
		{
			value: '메뉴 아이템 제목2',
			onClick: ... function
                        ... element props
		}
];

return (
    <DropDownMenu menuItems={menuItems}>
	    <CustomButton>버튼</CustomButton>
    </DropDownMenu>
)
```

## 관련 이슈
close #7