### PR TITLE
Project 페이지 기본 구조 구현

### DIFF
--- a/cocode/src/components/Browser/index.js
+++ b/cocode/src/components/Browser/index.js
@@ -35,13 +35,20 @@ function BrowserHeader({
 				defaultValue={addressInputURL}
 				onKeyUp={handleAddressInputKeyDown}
 				adressInputBGColor={theme.adressInputBGColor}
-				adressInputFontColor={theme.adressInputTextColor}
+				adressInputTextColor={theme.adressInputTextColor}
 			/>
 		</Styled.BrowserHeader>
 	);
 }
 
-function Browser({ onGoBackward, onGoForward, onReload, url, theme }) {
+function Browser({
+	className,
+	onGoBackward,
+	onGoForward,
+	onReload,
+	url,
+	theme
+}) {
 	const [addressInputURL, setAddressInput] = useState(
 		url ? url : DEFAULT_URL
 	);
@@ -53,7 +60,7 @@ function Browser({ onGoBackward, onGoForward, onReload, url, theme }) {
 	};
 
 	return (
-		<Styled.Browser height={theme.browserHeignt}>
+		<Styled.Browser className={className} height={theme.browserHeignt}>
 			<BrowserHeader
 				onGoBackward={onGoBackward}
 				onGoForward={onGoForward}

--- a/cocode/src/components/MonacoEditor/index.js
+++ b/cocode/src/components/MonacoEditor/index.js
@@ -2,16 +2,19 @@ import React from 'react';
 import { ControlledEditor } from '@monaco-editor/react';
 import * as Styled from './style';
 
-function MonacoEditor() {
-    return (
-        <Styled.MonacoEditor>
-            <ControlledEditor
-                height="100vh"
-                language="javascript"
-                theme="vs-dark"
-            />
-        </Styled.MonacoEditor>
-    );
+function MonacoEditor(props) {
+	return (
+		<Styled.MonacoEditor {...props}>
+			<ControlledEditor
+				value={'// 🥥 welcome to cocode 🥥 //\n'}
+				language="javascript"
+				theme="vs-dark"
+				options={{
+					fontSize: '16px'
+				}}
+			/>
+		</Styled.MonacoEditor>
+	);
 }
 
 export default MonacoEditor;

--- a/cocode/src/components/TabBar/index.js
+++ b/cocode/src/components/TabBar/index.js
@@ -7,9 +7,6 @@ function TabBar({ theme }) {
 	return (
 		<Styled.TabBar backGroundColor={theme.tabBarBGColor}>
 			<Styled.TabBarItem>
-				<ProjectIcon fillColor={theme.tabBarItemBGColor} />
-			</Styled.TabBarItem>
-			<Styled.TabBarItem>
 				<ProjectIcon fillColor={theme.tabBarSelectedItemBGColor} />
 			</Styled.TabBarItem>
 		</Styled.TabBar>

--- a/cocode/src/components/TabBar/style.js
+++ b/cocode/src/components/TabBar/style.js
@@ -6,8 +6,6 @@ const TabBar = styled.nav`
 		flex-direction: column;
 		justify-content: flex-start;
 
-		height: 100vh;
-
 		background-color: ${({ tabBarBGColor }) => tabBarBGColor};
 	}
 `;

--- a/cocode/src/containers/Editor/index.js
+++ b/cocode/src/containers/Editor/index.js
@@ -1,15 +1,16 @@
 import React from 'react';
+import * as Styled from './style';
 
 import FileTabBar from 'components/FileTabBar';
 import MonacoEditor from 'components/MonacoEditor';
 
 function Editor() {
-    return (
-        <>
-            <FileTabBar />
-            <MonacoEditor />
-        </>
-    );
+	return (
+		<Styled.Editor>
+			<FileTabBar />
+			<MonacoEditor className="Stretch-width" />
+		</Styled.Editor>
+	);
 }
 
 export default Editor;

--- a/cocode/src/containers/Editor/style.js
+++ b/cocode/src/containers/Editor/style.js
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+const Editor = styled.section`
+	& {
+		display: flex;
+		flex-direction: column;
+
+		/* temp width */
+		width: 20rem;
+	}
+
+	.Stretch-width {
+		flex-grow: 2;
+	}
+`;
+
+export { Editor };

--- a/cocode/src/containers/ProjectTab/style.js
+++ b/cocode/src/containers/ProjectTab/style.js
@@ -3,8 +3,8 @@ import { TAB_CONTAINER_THEME } from 'constants/theme';
 
 const ProjectTab = styled.section`
 	& {
-		width: 100%;
-		height: 100vh;
+		/* temp width */
+		width: 15rem;
 
 		background-color: ${TAB_CONTAINER_THEME.tabContainerBGColor};
 	}

--- a/cocode/src/pages/Project/index.js
+++ b/cocode/src/pages/Project/index.js
@@ -1,13 +1,27 @@
 import React from 'react';
+import * as Styled from './style';
+
+import Header from 'containers/Header';
+import TabBar from 'components/TabBar';
+import ProjectTab from 'containers/ProjectTab';
+import Editor from 'containers/Editor';
+import Browser from 'components/Browser';
+
+import { TAB_BAR_THEME, BROWSER_THEME } from 'constants/theme';
 
 function Project() {
 	return (
 		<>
-			<header>
-				<h1>Hello! Project!!</h1>
-			</header>
-			<section></section>
-			<footer></footer>
+			<Header />
+			<Styled.Main>
+				<TabBar theme={TAB_BAR_THEME} />
+				<ProjectTab />
+				<Editor />
+				<Browser
+					className="Project-main-stretch"
+					theme={BROWSER_THEME}
+				/>
+			</Styled.Main>
 		</>
 	);
 }

--- a/cocode/src/pages/Project/style.js
+++ b/cocode/src/pages/Project/style.js
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+const Main = styled.main`
+	& {
+		display: flex;
+		flex-direction: row;
+
+		height: 88.8vh;
+
+		.Project-main-stretch {
+			flex-grow: 2;
+		}
+	}
+`;
+
+export { Main };


### PR DESCRIPTION
## 간단한 요약 설명
project page를 구성하는 컴포넌트들을 가지고 project page의 기본 골격을 구현했습니다.
현재 컴포넌트 간이나 컴포넌트의 event 처리는 구현되지 않은 상태이고 추후 구현이 필요합니다.
컴포넌트들을 조합하면서 서로 안맞는 부분을 조금씩 수정했습니다.

## 관련 이슈
close #110 