### PR TITLE
Cocode V1 구현 (context, reducer 도입해보기)

### DIFF
--- a/cocode/public/index.html
+++ b/cocode/public/index.html
@@ -11,6 +11,14 @@
 	<body>
 		<div id="root"></div>
 		<div id="modal"></div>
+		<script
+			src="https://unpkg.com/react@16/umd/react.development.js"
+			crossorigin
+		></script>
+		<script
+			src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"
+			crossorigin
+		></script>
 		<script src="./bundle.js"></script>
 	</body>
 </html>

--- a/cocode/src/actions/Project.js
+++ b/cocode/src/actions/Project.js
@@ -1,0 +1,9 @@
+export const UPDATE_CODE = 'updateCode';
+export function updateCodeActionCreator(payload) {
+	return { type: UPDATE_CODE, payload };
+}
+
+export const FETCH_PROJECT = 'fetchProject';
+export function fetchProjectActionCreator() {
+	return { type: FETCH_PROJECT };
+}

--- a/cocode/src/components/BrowserV1/index.js
+++ b/cocode/src/components/BrowserV1/index.js
@@ -1,0 +1,23 @@
+import React, { useEffect } from 'react';
+import * as Styled from './style';
+
+import * as babel from '@babel/core';
+import reactPreset from '@babel/preset-react';
+
+function BrowserV1({ code, ...props }) {
+	const buildCode = () => {
+		try {
+			const parsedCode = babel.transform(code, {
+				presets: [reactPreset]
+			});
+			eval(parsedCode.code);
+		} catch (e) {
+			console.log(e);
+		}
+	};
+
+	useEffect(buildCode, [code]);
+	return <Styled.BrowserV1 {...props}></Styled.BrowserV1>;
+}
+
+export default BrowserV1;

--- a/cocode/src/components/BrowserV1/style.js
+++ b/cocode/src/components/BrowserV1/style.js
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+const BrowserV1 = styled.div`
+	& {
+		height: ${({ height }) => height};
+
+		background-color: white;
+		color: black;
+	}
+`;
+
+export { BrowserV1 };

--- a/cocode/src/components/MonacoEditor/index.js
+++ b/cocode/src/components/MonacoEditor/index.js
@@ -2,16 +2,17 @@ import React from 'react';
 import { ControlledEditor } from '@monaco-editor/react';
 import * as Styled from './style';
 
-function MonacoEditor(props) {
+function MonacoEditor({ code, onChange, ...props }) {
 	return (
 		<Styled.MonacoEditor {...props}>
 			<ControlledEditor
-				value={'// 🥥 welcome to cocode 🥥 //\n'}
+				value={code ? code : '// 🥥 welcome to cocode 🥥 //\n'}
 				language="javascript"
 				theme="vs-dark"
 				options={{
 					fontSize: '16px'
 				}}
+				onChange={onChange}
 			/>
 		</Styled.MonacoEditor>
 	);

--- a/cocode/src/containers/Editor/index.js
+++ b/cocode/src/containers/Editor/index.js
@@ -1,14 +1,29 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import * as Styled from './style';
 
 import FileTabBar from 'components/FileTabBar';
 import MonacoEditor from 'components/MonacoEditor';
 
+import ProjectContext from 'contexts/ProjectContext';
+import { updateCodeActionCreator } from 'actions/Project';
+
 function Editor() {
+	const { project, dispatchProject } = useContext(ProjectContext);
+	const { code } = project;
+
+	const handleChangeCode = (_, changedCode) => {
+		const updateCodeAction = updateCodeActionCreator(changedCode);
+		dispatchProject(updateCodeAction);
+	};
+
 	return (
 		<Styled.Editor>
 			<FileTabBar />
-			<MonacoEditor className="Stretch-width" />
+			<MonacoEditor
+				code={code}
+				onChange={handleChangeCode}
+				className="Stretch-width"
+			/>
 		</Styled.Editor>
 	);
 }

--- a/cocode/src/containers/Editor/style.js
+++ b/cocode/src/containers/Editor/style.js
@@ -6,7 +6,7 @@ const Editor = styled.section`
 		flex-direction: column;
 
 		/* temp width */
-		width: 20rem;
+		width: 30rem;
 	}
 
 	.Stretch-width {

--- a/cocode/src/contexts/ProjectContext.js
+++ b/cocode/src/contexts/ProjectContext.js
@@ -1,0 +1,9 @@
+import PropTypes from 'prop-types';
+import { createContext } from 'react';
+
+const ProjectContext = createContext();
+ProjectContext.propTypes = {
+	code: PropTypes.string
+};
+
+export default ProjectContext;

--- a/cocode/src/pages/Project/index.js
+++ b/cocode/src/pages/Project/index.js
@@ -1,28 +1,42 @@
-import React from 'react';
+import React, { useReducer, useEffect } from 'react';
 import * as Styled from './style';
 
 import Header from 'containers/Header';
 import TabBar from 'components/TabBar';
 import ProjectTab from 'containers/ProjectTab';
 import Editor from 'containers/Editor';
-import Browser from 'components/Browser';
+import BrowserV1 from 'components/BrowserV1';
 
-import { TAB_BAR_THEME, BROWSER_THEME } from 'constants/theme';
+import ProjectReducer from 'reducers/ProjectReducer';
+import ProjectContext from 'contexts/ProjectContext';
+import { fetchProjectActionCreator } from 'actions/Project';
+
+import { TAB_BAR_THEME } from 'constants/theme';
 
 function Project() {
+	const [project, dispatchProject] = useReducer(ProjectReducer, {});
+
+	const handleFetchProject = () => {
+		const fetchProjectAction = fetchProjectActionCreator();
+		dispatchProject(fetchProjectAction);
+	};
+
+	useEffect(handleFetchProject, []);
+
 	return (
-		<>
+		<ProjectContext.Provider value={{ project, dispatchProject }}>
 			<Header />
 			<Styled.Main>
 				<TabBar theme={TAB_BAR_THEME} />
 				<ProjectTab />
 				<Editor />
-				<Browser
+				<BrowserV1
+					code={project.code}
+					id="coconut-root"
 					className="Project-main-stretch"
-					theme={BROWSER_THEME}
 				/>
 			</Styled.Main>
-		</>
+		</ProjectContext.Provider>
 	);
 }
 

--- a/cocode/src/reducers/ProjectReducer.js
+++ b/cocode/src/reducers/ProjectReducer.js
@@ -1,0 +1,34 @@
+import { UPDATE_CODE, FETCH_PROJECT } from 'actions/Project';
+
+const INITIAL_CODE = `const { useState } = React;
+
+function App() {
+	const [state, setState] = useState('Cocode');
+	
+	return(
+		<>
+			<h1>Hi! {state}</h1>
+		</>
+	)
+}
+
+ReactDOM.render(<App />, document.getElementById('coconut-root'));
+`;
+
+function ProjectReducer(state, { type, payload }) {
+	switch (type) {
+		case UPDATE_CODE: {
+			return { ...state, code: payload };
+		}
+		case FETCH_PROJECT: {
+			// TODO: API server에 fetch 요청 보내서 가져오기
+			const fetchedProject = { code: INITIAL_CODE };
+			return fetchedProject;
+		}
+		default: {
+			throw new Error(`unexpected action.type: ${type}`);
+		}
+	}
+}
+
+export default ProjectReducer;


### PR DESCRIPTION
## 간단한 요약 설명
- 3주차 데모를 위한 cocode 첫번째 버전을 구현해보았습니다.
- 팀원들이 작업한 결과물들을 취합했습니다.
- react hooks API인 context, reducer를 이용하여 app의 전반적인 상태관리를 구현해보았습니다.(도입기)

# Context, Reducer를 이용한 App의 상태관리
상위 컴포넌트에서 하위 컴포넌트 까지 depth가 깊어질 수 상태관리의 복잡성이 커집니다.
이를 어떻게 해결할까 고민했는데 Context, Reducer를 가지고 잘 해결해 볼 수 있을 것 같다고 생각했습니다.

Context에서 전역적으로 상태를 관리하여 state를 관리하고,
Reducer에서 넘어온 action의 type에 따라 state를 수정합니다.

이 과정에서 Reducer로 넘겨주는 action의 역할을 명시하여 관리해주기 위해 Action도 관리하면 좋을 것 같다고 생각했습니다.

그래서 전반적인 과정을 정리해보자면,
```
1. view에서 event발생
2. event에 따른 action생성
3. context로 제공되는 reducer의 dispatch에 action주입
4. reducer에서 action에 따른 state 관리
5. view에 적용 됨!
```

두서가 없지만 정리해보았습니다.
제가 정리한 것이 이해가 잘안되시면 이야기부탁드려요!