### PR TITLE
[제안] Cocode history page 구현

### DIFF
--- a/cocode/src/App.js
+++ b/cocode/src/App.js
@@ -3,7 +3,7 @@ import GlobalStyle from './components/GlobalStyle';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 
-import { Home, DashBoard, Project } from './pages';
+import { Home, DashBoard, Project, History } from './pages';
 
 import { DEFAULT_THEME } from './constants/theme';
 
@@ -16,6 +16,7 @@ function App() {
 					<Route exact path="/" component={Home} />
 					<Route path="/dashboard" component={DashBoard} />
 					<Route path="/project" component={Project} />
+					<Route path="/history" component={History} />
 				</Switch>
 			</ThemeProvider>
 		</Router>

--- a/cocode/src/components/GlobalStyle/index.js
+++ b/cocode/src/components/GlobalStyle/index.js
@@ -63,6 +63,17 @@ const GlobalStyle = createGlobalStyle`
         cursor: pointer;
         color: ${({ theme }) => theme.textColor};
     }
+
+    a,
+	a:visited,
+	a:active {
+		color: ${({ theme }) => theme.textColor};
+		cursor: pointer;
+	}
+
+	a:hover {
+		color: ${({ theme }) => theme.mainColor};
+	}
 `;
 
 export default GlobalStyle;

--- a/cocode/src/constants/theme.js
+++ b/cocode/src/constants/theme.js
@@ -3,7 +3,10 @@ const DEFAULT_THEME = {
 	mainOpaqueColor: '#2accf9b3',
 	backgroundColor: '#161419',
 	blackOpaqueColor: '#000000b3',
-	textColor: '#ffffff'
+	textColor: '#ffffff',
+
+	exceptHeaderHeignt: '88vh',
+	headerHeignt: '12vh'
 };
 
 const BROWSER_THEME = {
@@ -11,7 +14,7 @@ const BROWSER_THEME = {
 	adressInputBGColor: '#000',
 	adressInputTextColor: '#fff',
 
-	browserHeignt: '88.8vh'
+	browserHeignt: '88vh'
 };
 
 const TAB_CONTAINER_THEME = {

--- a/cocode/src/containers/Header/index.js
+++ b/cocode/src/containers/Header/index.js
@@ -33,30 +33,40 @@ function Header() {
 		if (data) setUser(data.data);
 	};
 
-	useEffect(() => { getJwtToken(); }, []);
+	useEffect(() => {
+		getJwtToken();
+	}, []);
 
 	return (
 		<Styled.Header>
-			<Link to="/"><Logo /></Link>
-			{ user ?
-				<UserProfile
-					username={user.username}
-					avatar={user.avatar}
-				/> :
-				<>
-					<Styled.SignInButton onClick={handleOpenSignInModal}>
-						Sign In
-					</Styled.SignInButton>
-					{ isSignInModalOpen && (
-						<ModalPortal>
-							<Modal
-								modalBody={<LoginModalBody />}
-								onClose={handleCloseSignInModal}
-							/>
-						</ModalPortal>
-					)}
-				</>
-			}
+			<Link to="/">
+				<Logo />
+			</Link>
+			<Link to="/history">
+				<Styled.HeaderCategory>History</Styled.HeaderCategory>
+			</Link>
+			<Styled.HeaderRightSideArea>
+				{user ? (
+					<UserProfile
+						username={user.username}
+						avatar={user.avatar}
+					/>
+				) : (
+					<>
+						<Styled.SignInButton onClick={handleOpenSignInModal}>
+							Sign In
+						</Styled.SignInButton>
+						{isSignInModalOpen && (
+							<ModalPortal>
+								<Modal
+									modalBody={<LoginModalBody />}
+									onClose={handleCloseSignInModal}
+								/>
+							</ModalPortal>
+						)}
+					</>
+				)}
+			</Styled.HeaderRightSideArea>
 		</Styled.Header>
 	);
 }

--- a/cocode/src/containers/Header/style.js
+++ b/cocode/src/containers/Header/style.js
@@ -7,7 +7,7 @@ const Header = styled.header`
 		justify-content: flex-start;
 		align-items: center;
 
-		height: 12vh;
+		height: ${({ theme }) => theme.headerHeignt};
 
 		background-color: ${({ theme }) => theme.backgroundColor};
 		padding: 2rem 2.3rem;

--- a/cocode/src/containers/Header/style.js
+++ b/cocode/src/containers/Header/style.js
@@ -1,28 +1,43 @@
 import styled from 'styled-components';
 
 const Header = styled.header`
-    & {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        align-items: center;
-    
-        height: 12vh;
-    
-        background-color: ${({ theme }) => theme.backgroundColor};
-        padding: 2rem 2.3rem;
-    }
-`;
+	& {
+		display: flex;
+		flex-direction: row;
+		justify-content: flex-start;
+		align-items: center;
 
-const SignInButton = styled.button`
-    & {
-        font-size: 1.4rem;
-        font-weight: 100;
-    }
-	
-	&:hover {
-	    font-weight: 400;
+		height: 12vh;
+
+		background-color: ${({ theme }) => theme.backgroundColor};
+		padding: 2rem 2.3rem;
 	}
 `;
 
-export { Header, SignInButton };
+const HeaderCategory = styled.button`
+	& {
+		margin-left: 1.5rem;
+
+		font-size: 1.4rem;
+		font-weight: 100;
+	}
+`;
+
+const HeaderRightSideArea = styled.div`
+	& {
+		margin-left: auto;
+	}
+`;
+
+const SignInButton = styled.button`
+	& {
+		font-size: 1.4rem;
+		font-weight: 100;
+	}
+
+	&:hover {
+		font-weight: 400;
+	}
+`;
+
+export { Header, SignInButton, HeaderCategory, HeaderRightSideArea };

--- a/cocode/src/containers/History/CocodeHistory/index.js
+++ b/cocode/src/containers/History/CocodeHistory/index.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import * as Styled from './style';
+
+const VERSION_HISTORIES = [
+	{
+		title: 'Version 1',
+		link: '/history/version1',
+		descriptions: ['하나의 React File을 build 할 수 있습니다']
+	}
+];
+
+function HistoryItem({ title, link, descriptions }) {
+	return (
+		<Styled.Version>
+			<Styled.VersionTitle>
+				<Link to={link}>{title}</Link>
+			</Styled.VersionTitle>
+			<Styled.VersionDesctiption>
+				{descriptions.map((description, index) => (
+					<li key={index}>{description}</li>
+				))}
+			</Styled.VersionDesctiption>
+		</Styled.Version>
+	);
+}
+
+function CocodeHistory() {
+	return (
+		<Styled.CocodeHistory>
+			{VERSION_HISTORIES.map((history, index) => {
+				return <HistoryItem key={index} {...history} />;
+			})}
+		</Styled.CocodeHistory>
+	);
+}
+
+export default CocodeHistory;

--- a/cocode/src/containers/History/CocodeHistory/style.js
+++ b/cocode/src/containers/History/CocodeHistory/style.js
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+
+const CocodeHistory = styled.main`
+	text-align: center;
+`;
+
+const Version = styled.section`
+	padding: 5rem;
+`;
+
+const VersionTitle = styled.h1`
+	font-size: 4rem;
+	font-weight: normal;
+`;
+
+const VersionDesctiption = styled.ul`
+	margin-top: 1rem;
+
+	list-style-type: none;
+
+	font-size: 2rem;
+	font-weight: lighter;
+
+	li {
+		margin: 0.5rem 0;
+	}
+`;
+
+export { CocodeHistory, Version, VersionTitle, VersionDesctiption };

--- a/cocode/src/pages/History/index.js
+++ b/cocode/src/pages/History/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+
+import { Version1 } from 'pages';
+import Header from 'containers/Header';
+import CocodeHistory from 'containers/History/CocodeHistory';
+
+function HistoryHome() {
+	return <CocodeHistory />;
+}
+
+function History({ match }) {
+	return (
+		<>
+			<Header />
+			<Route exact path={match.url} render={HistoryHome} />
+			<Route path={`${match.url}/version1`} component={Version1} />
+		</>
+	);
+}
+
+export default History;

--- a/cocode/src/pages/Version1/index.js
+++ b/cocode/src/pages/Version1/index.js
@@ -1,0 +1,45 @@
+import React, { useReducer, useEffect } from 'react';
+import * as Styled from './style';
+
+import MonacoEditor from 'components/MonacoEditor';
+import BrowserV1 from 'components/BrowserV1';
+
+import ProjectReducer from 'reducers/ProjectReducer';
+
+import {
+	fetchProjectActionCreator,
+	updateCodeActionCreator
+} from 'actions/Project';
+
+function Version1() {
+	const [project, dispatchProject] = useReducer(ProjectReducer, {});
+
+	const handleFetchProject = () => {
+		const fetchProjectAction = fetchProjectActionCreator();
+		dispatchProject(fetchProjectAction);
+	};
+
+	const handleChangeCode = (_, changedCode) => {
+		const updateCodeAction = updateCodeActionCreator(changedCode);
+		dispatchProject(updateCodeAction);
+	};
+
+	useEffect(handleFetchProject, []);
+
+	return (
+		<Styled.Main>
+			<MonacoEditor
+				className="Stretch-item"
+				code={project.code}
+				onChange={handleChangeCode}
+			/>
+			<BrowserV1
+				className="Stretch-item"
+				code={project.code}
+				id="coconut-root"
+			/>
+		</Styled.Main>
+	);
+}
+
+export default Version1;

--- a/cocode/src/pages/Version1/style.js
+++ b/cocode/src/pages/Version1/style.js
@@ -5,7 +5,7 @@ const Main = styled.main`
 		display: flex;
 		flex-direction: row;
 
-		height: 88.8vh;
+		height: ${({ theme }) => theme.exceptHeaderHeignt};
 	}
 
 	.Stretch-item {

--- a/cocode/src/pages/Version1/style.js
+++ b/cocode/src/pages/Version1/style.js
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+const Main = styled.main`
+	& {
+		display: flex;
+		flex-direction: row;
+
+		height: 88.8vh;
+	}
+
+	.Stretch-item {
+		width: 100%;
+	}
+`;
+
+export { Main };

--- a/cocode/src/pages/index.js
+++ b/cocode/src/pages/index.js
@@ -1,5 +1,7 @@
 import Home from './Home';
 import DashBoard from './DashBoard';
 import Project from './Project';
+import History from './History';
+import Version1 from './Version1';
 
-export { Home, DashBoard, Project };
+export { Home, DashBoard, Project, History, Version1 };


### PR DESCRIPTION
## 간단한 요약 설명
- issue #135 에서 제안한 내용을구현해보았습니다.
- Home page입니다. header에 history 를 추가했습니다.
![image](https://user-images.githubusercontent.com/30258523/69492360-5388df00-0ee5-11ea-9efb-df1c74c5c4e5.png)
- History page입니다. Version1에 마우스를 올리면 main color로 색상이 변경되며 클릭시 해당 version의 페이지로 이동합니다.
![image](https://user-images.githubusercontent.com/30258523/69492362-5f74a100-0ee5-11ea-9031-73cb3211153f.png)
- Version1 page입니다. 하나의 파일에 대한 editor와 browser를 볼 수 있습니다.
![image](https://user-images.githubusercontent.com/30258523/69492371-859a4100-0ee5-11ea-802d-2483f5b6fffe.png)


## 관련 이슈
close #135 