### PR TITLE
메인 페이지 스크롤 속도 문제 개선

### DIFF
--- a/cocode/src/utils/addWheelEvent.js
+++ b/cocode/src/utils/addWheelEvent.js
@@ -1,45 +1,18 @@
-let marker = true;
-let scroll = true;
-let delta;
-let counter1 = 0;
-let counter2;
+let scroll = false;
 
-function wheel (e) {
-    counter1++;
-    delta = e.deltaY;
-    if (marker) wheelStart();
-};
-
-function wheelStart () {
-    marker = false;
-    wheelAct();
-};
-
-function wheelAct () {
-    counter2 = counter1;
-    setTimeout(() => {
-        if (counter2 === counter1) return wheelEnd();
-        if (scroll) return scrollMove();
-        return wheelAct();
-    }, 10);
-};
-
-function wheelEnd() {
-    marker = true;
-    scroll = true;
-    counter1 = 0;
-    counter2 = false;
-};
-
-function scrollMove() {
-    scroll = false;
-    if (delta > 0) window.scrollBy(0, -window.innerHeight);
-    else if (delta < 0) window.scrollBy(0, window.innerHeight);
-    wheelAct();
-};
+function handleWheelScroll(e) {
+	if (scroll) return;
+	scroll = true;
+	if (e.deltaY < 0) window.scrollBy(0, -window.innerHeight);
+	else window.scrollBy(0, window.innerHeight);
+	wheelTimer = setTimeout(handleWheelAble, 1000);
+}
+function handleWheelAble() {
+	scroll = false;
+}
 
 function addWheelEvent() {
-    window.addEventListener('wheel', wheel);
+	window.addEventListener('wheel', handleWheelScroll);
 }
 
 export default addWheelEvent;

--- a/cocode/src/utils/addWheelEvent.js
+++ b/cocode/src/utils/addWheelEvent.js
@@ -1,14 +1,14 @@
-let scroll = false;
+let isScrollable = false;
 
 function handleWheelScroll(e) {
-	if (scroll) return;
-	scroll = true;
+	if (isScrollable) return;
+	isScrollable = true;
 	if (e.deltaY < 0) window.scrollBy(0, -window.innerHeight);
 	else window.scrollBy(0, window.innerHeight);
-	wheelTimer = setTimeout(handleWheelAble, 1000);
+	setTimeout(handleWheelAble, 1000);
 }
 function handleWheelAble() {
-	scroll = false;
+	isScrollable = false;
 }
 
 function addWheelEvent() {


### PR DESCRIPTION
## 간단한 요약 설명
메인 페이지의 wheel, scroll 이벤트를 리팩토링하였습니다.
wheel 이벤트와 scroll 이벤트를 debounce 기법을 적용하여 이벤트가 한 번만 실행되도록 하였습니다.


## 관련 이슈
close #142 
