### PR TITLE
fix: 500 에러 반환하는 프로젝트 목록 조회 API 에러 수정

### DIFF
--- a/api-server/src/routes/users/controller.js
+++ b/api-server/src/routes/users/controller.js
@@ -14,8 +14,8 @@ async function sendUserData(req, res) {
 
 async function getProjectsByUsername(req, res) {
 	Project.find({ author: req.params.username })
-		.then(projects => res.status(200).json(projects))
-		.catch(res.status(500).json({}));
+		.then(projects => res.status(200).send(projects))
+		.catch(() => res.status(500).send({}));
 }
 
 export { sendUserData, getProjectsByUsername };


### PR DESCRIPTION
## 간단한 요약 설명

catch 문에 콜백이 아닌 res.send만 넣어서 발생했습니다.
수정했습니다.

# 이제부터 더 꼼꼼한 김희라가 되도록 하겠습니다. 

## 관련 이슈
* close #149 