### PR TITLE
bundler 프로토타입 작성

### DIFF
--- a/cocode/src/bundler/core.js
+++ b/cocode/src/bundler/core.js
@@ -1,0 +1,28 @@
+import * as babel from '@babel/core';
+import presetEnv from '@babel/preset-env';
+import presetReact from '@babel/preset-react';
+import { pathStack, exports } from './global';
+
+function transformCode(code) {
+	try {
+		const result = babel.transform(code, {
+			presets: [presetEnv, presetReact]
+		});
+		return {
+			state: true,
+			value: result.code
+		};
+	} catch (error) {
+		return {
+			state: false,
+			value: error.message
+		};
+	}
+}
+
+function init() {
+	while (pathStack.length) pathStack.pop();
+	pathStack.push('');
+}
+
+export { transformCode, init };

--- a/cocode/src/bundler/global.js
+++ b/cocode/src/bundler/global.js
@@ -1,0 +1,4 @@
+const exports = {};
+const pathStack = [];
+
+export { exports, pathStack };

--- a/cocode/src/bundler/index.js
+++ b/cocode/src/bundler/index.js
@@ -1,0 +1,6 @@
+import { transformCode, init } from './core';
+import { exports, pathStack } from './global';
+import { require } from './require';
+import { pathParser } from './pathParser';
+
+export { transformCode,init, exports, pathStack, require, pathParser };

--- a/cocode/src/bundler/pathParser.js
+++ b/cocode/src/bundler/pathParser.js
@@ -1,0 +1,41 @@
+import { pathStack, exports } from './global';
+
+function pathParser(path, fileSystem = exports) {
+	const [parsedPath, splitedPath] = pathInitializer(path, fileSystem);
+
+	splitedPath.forEach(dir => {
+		if (dir === '.') return;
+		if (dir === '..') {
+			if (parsedPath.length === 0) throw new Error('path error');
+			parsedPath.pop();
+		} else parsedPath.push(dir);
+	});
+
+	const newPath = parsedPath.reduce((acc, current) => {
+		if (current === '') return acc;
+		acc += `/${current}`;
+		return acc;
+	}, '');
+
+	parsedPath.pop();
+	const newPathParent = parsedPath.reduce((acc, current) => {
+		if (current === '') return acc;
+		acc += `/${current}`;
+		return acc;
+	}, '');
+	return [`${newPath}.js`, newPathParent];
+	// 확장자 관련 코드 필요..
+}
+
+function pathInitializer(path) {
+	// node_modules 의존성 검사 필요
+
+	const splitedPath = path.split('/').filter(val => val !== '');
+
+	const initialPath = pathStack[pathStack.length - 1]
+		.split('/')
+		.filter(fileName => fileName !== '');
+	return [initialPath, splitedPath];
+}
+
+export { pathParser };

--- a/cocode/src/bundler/pathParser.js
+++ b/cocode/src/bundler/pathParser.js
@@ -29,7 +29,6 @@ function pathParser(path, fileSystem = exports) {
 
 function pathInitializer(path) {
 	// node_modules 의존성 검사 필요
-
 	const splitedPath = path.split('/').filter(val => val !== '');
 
 	const initialPath = pathStack[pathStack.length - 1]

--- a/cocode/src/bundler/require.js
+++ b/cocode/src/bundler/require.js
@@ -4,6 +4,8 @@ import { transformCode } from './core';
 
 function require(path, fileSystem = exports) {
 	const [newPath, newPathParent] = pathParser(path, fileSystem);
+	console.log(newPath);
+
 	pathStack.push(newPathParent);
 	const code = transformCode(fileSystem[newPath].contents).value;
 	const result = eval(`

--- a/cocode/src/bundler/require.js
+++ b/cocode/src/bundler/require.js
@@ -4,7 +4,6 @@ import { transformCode } from './core';
 
 function require(path, fileSystem = exports) {
 	const [newPath, newPathParent] = pathParser(path, fileSystem);
-	console.log(newPath);
 
 	pathStack.push(newPathParent);
 	const code = transformCode(fileSystem[newPath].contents).value;

--- a/cocode/src/bundler/require.js
+++ b/cocode/src/bundler/require.js
@@ -1,0 +1,19 @@
+import { pathStack, exports } from './global';
+import { pathParser } from './pathParser';
+import { transformCode } from './core';
+
+function require(path, fileSystem = exports) {
+	const [newPath, newPathParent] = pathParser(path, fileSystem);
+	pathStack.push(newPathParent);
+	const code = transformCode(fileSystem[newPath].contents).value;
+	const result = eval(`
+    (() => {
+      const exports = {};
+      ${code}
+      return exports;
+    })();`);
+	pathStack.pop();
+	return result;
+}
+
+export { require };

--- a/cocode/src/components/Project/BrowserV1/index.js
+++ b/cocode/src/components/Project/BrowserV1/index.js
@@ -1,22 +1,62 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import * as Styled from './style';
 
-import * as babel from '@babel/core';
-import reactPreset from '@babel/preset-react';
+import ProjectContext from 'contexts/ProjectContext';
+// import { updateCodeActionCreator } from 'actions/Project';
+import * as bundler from 'bundler';
+
+// import * as babel from '@babel/core';
+// import reactPreset from '@babel/preset-react';
 
 function BrowserV1({ code, ...props }) {
-	const buildCode = () => {
-		try {
-			const parsedCode = babel.transform(code, {
-				presets: [reactPreset]
-			});
-			eval(parsedCode.code);
-		} catch (e) {
-			console.log(e);
-		}
-	};
+	const { project, dispatchProject } = useContext(ProjectContext);
+	const { files, entry, selectedFileId } = project;
+	const [fileSystem, setFileSystem] = useState({});
+	// const buildCode = () => {
+	// 	try {
+	// 		const parsedCode = babel.transform(code, {
+	// 			presets: [reactPreset]
+	// 		});
+	// 		eval(parsedCode.code);
+	// 	} catch (e) {
+	// 		console.log(e);
+	// 	}
+	// };
 
-	useEffect(buildCode, [code]);
+	// useEffect(buildCode, [files]);
+	useEffect(() => {
+		const fileTemp = {};
+		Object.keys(bundler.exports).forEach(key => {
+			delete bundler.exports[key];
+		});
+		function fileParser(id, path = '') {
+			if (files[id].type !== 'directory') {
+				fileTemp[`${path}/${files[id].name}`] = {
+					contents: files[id].contents
+				};
+				bundler.exports[`${path}/${files[id].name}`] = {
+					contents: files[id].contents
+				};
+			} else {
+				files[id].child.forEach(file => {
+					fileParser(file, `${path}/${files[id].name}`);
+				});
+			}
+		}
+		if (project) fileParser(project.root);
+
+		setFileSystem(fileTemp);
+	}, [files]);
+
+	useEffect(() => {
+		console.log(fileSystem);
+		try {
+			bundler.init();
+			bundler.require('/root/src/index');
+		} catch (error) {
+			console.log(error);
+		}
+	}, [fileSystem]);
 	return <Styled.BrowserV1 {...props}></Styled.BrowserV1>;
 }
 

--- a/cocode/src/components/Project/BrowserV1/index.js
+++ b/cocode/src/components/Project/BrowserV1/index.js
@@ -2,28 +2,13 @@ import React, { useState, useEffect, useContext } from 'react';
 import * as Styled from './style';
 
 import ProjectContext from 'contexts/ProjectContext';
-// import { updateCodeActionCreator } from 'actions/Project';
 import * as bundler from 'bundler';
-
-// import * as babel from '@babel/core';
-// import reactPreset from '@babel/preset-react';
 
 function BrowserV1({ code, ...props }) {
 	const { project, dispatchProject } = useContext(ProjectContext);
 	const { files, entry, selectedFileId } = project;
 	const [fileSystem, setFileSystem] = useState({});
-	// const buildCode = () => {
-	// 	try {
-	// 		const parsedCode = babel.transform(code, {
-	// 			presets: [reactPreset]
-	// 		});
-	// 		eval(parsedCode.code);
-	// 	} catch (e) {
-	// 		console.log(e);
-	// 	}
-	// };
 
-	// useEffect(buildCode, [files]);
 	useEffect(() => {
 		const fileTemp = {};
 		Object.keys(bundler.exports).forEach(key => {
@@ -49,7 +34,6 @@ function BrowserV1({ code, ...props }) {
 	}, [files]);
 
 	useEffect(() => {
-		console.log(fileSystem);
 		try {
 			bundler.init();
 			bundler.require('/root/src/index');

--- a/cocode/src/containers/Project/Editor/index.js
+++ b/cocode/src/containers/Project/Editor/index.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import * as Styled from './style';
 
 import FileTabBar from 'components/Project/FileTabBar';
@@ -10,22 +10,31 @@ import { updateCodeActionCreator } from 'actions/Project';
 function Editor() {
 	const { project, dispatchProject } = useContext(ProjectContext);
 	const { files, entry, selectedFileId } = project;
-	const entryCode = files[entry].contents;
+	const [code, setCode] = useState('');
 
-	const handleChangeCode = (_, changedCode) => {
-		const updateCodeAction = updateCodeActionCreator({
-			selectedFileId,
-			changedCode
-		});
-		dispatchProject(updateCodeAction);
+	const handleOnChange = (_, changedCode) => {
+		setCode(changedCode);
 	};
+
+	useEffect(() => {
+		if (selectedFileId === undefined) return;
+		setCode(files[selectedFileId].contents);
+	}, [selectedFileId]);
+
+	useEffect(() => {
+		if (code === '' || code === undefined) return;
+		dispatchProject(updateCodeActionCreator({
+			selectedFileId,
+			changedCode: code
+		}));
+	}, [code]);
 
 	return (
 		<Styled.Editor>
 			<FileTabBar />
 			<MonacoEditor
-				code={entryCode}
-				onChange={handleChangeCode}
+				code={code}
+				onChange={handleOnChange}
 				className="Stretch-width"
 			/>
 		</Styled.Editor>


### PR DESCRIPTION
## 간단한 요약 설명
클라이언트 사이드에서 빌드를 하기위해 필요한 함수를 작성하였습니다.

exports 개체에 각 파일의 정보가 들어갑니다. (변경가능)
```javascript
export = {
    '/src/index.js': {code, ...data},
    '/src/App.js': {code, ...data}
}
```
최초 실행 시 entry 파일을 require()함수로 실행시켜 사용할 수 있습니다.
```javascript
// ex
const ENTRY_FILE = '/src/index';
require(ENTRY_FILE); 
```
파일 확장자는 현재 .js만 사용합니다.
pathParser에서 확장자를 .js로 붙이기때문에 최초실행시 .js를 제외한 경로를 써주어야합니다.

프로젝트 페이지의 파일 탐색기 파일 클릭시 선택된 파일이 랜더링 되고 해당 파일을 수정할 수 있는 기능을 추가하였습니다.