### PR TITLE
[우혜주] w4_원페이지 스크롤 및 콜백 내에서의 페이지 이동 및 상태 관리

### DIFF
--- a/cocode/src/containers/Common/Header/index.js
+++ b/cocode/src/containers/Common/Header/index.js
@@ -1,0 +1,74 @@
+import React, { useState, useContext } from 'react';
+import * as Styled from './style';
+import { Link } from 'react-router-dom';
+
+import deleteCookie from 'utils/deleteCookie';
+
+import Logo from 'components/Common/Logo';
+import Modal from 'components/Common/Modal';
+import UserProfile from 'components/Common/UserProfile';
+import ModalPortal from 'components/Common/ModalPortal';
+import LoginModalBody from 'components/Common/LoginModalBody';
+
+import UserContext from 'contexts/UserContext';
+
+function Header() {
+	const { user } = useContext(UserContext);
+	const [isSignInModalOpen, setIsSignInModalOpen] = useState(false);
+
+	const handleOpenSignInModal = () => setIsSignInModalOpen(true);
+	const handleCloseSignInModal = () => setIsSignInModalOpen(false);
+	const handleClickDashBoard = () => window.location.href = '../dashboard';
+	const handleSignOut = () => {
+		const confirm = window.confirm('로그아웃 하시겠습니까?');
+		if (!confirm) return;
+		deleteCookie('jwt');
+	};
+
+	const profileDropDownMenuItems = [
+		{
+			value: 'dashboard',
+			onClick: handleClickDashBoard
+		},
+		{
+			value: 'sign out',
+			onClick: handleSignOut
+		}
+	];
+
+	return (
+		<Styled.Header>
+			<Link to="/">
+				<Logo />
+			</Link>
+			<Link to="/history">
+				<Styled.HeaderCategory>History</Styled.HeaderCategory>
+			</Link>
+			<Styled.HeaderRightSideArea>
+				{user ? (
+					<UserProfile
+						username={user.username}
+						avatar={user.avatar}
+						menuItems={profileDropDownMenuItems}
+					/>
+				) : (
+					<>
+						<Styled.SignInButton onClick={handleOpenSignInModal}>
+							Sign In
+						</Styled.SignInButton>
+						{isSignInModalOpen && (
+							<ModalPortal>
+								<Modal
+									modalBody={<LoginModalBody />}
+									onClose={handleCloseSignInModal}
+								/>
+							</ModalPortal>
+						)}
+					</>
+				)}
+			</Styled.HeaderRightSideArea>
+		</Styled.Header>
+	);
+}
+
+export default Header;

--- a/cocode/src/containers/Project/TabContainer/index.js
+++ b/cocode/src/containers/Project/TabContainer/index.js
@@ -1,0 +1,32 @@
+import React, { useEffect, useContext } from 'react';
+import * as Styled from './style';
+
+import ProjectContext from 'contexts/ProjectContext';
+
+import InfoTab from '../InfoTab';
+import ExplorerTab from '../ExplorerTab';
+import DependencyTab from '../DependencyTab';
+
+function TabContainer() {
+	const { clickedTabIndex } = useContext(ProjectContext);
+
+	const tapMapping = {
+		0: <InfoTab />,
+		1: <ExplorerTab />,
+		2: <DependencyTab />
+	};
+
+	const renderTab = () => tapMapping[clickedTabIndex];
+
+	useEffect(() => {
+		renderTab();
+	}, [clickedTabIndex]);
+
+	return (
+		<Styled.Container>
+			{renderTab()}
+		</Styled.Container>
+	);
+}
+
+export default TabContainer;

--- a/cocode/src/pages/Project/index.js
+++ b/cocode/src/pages/Project/index.js
@@ -1,0 +1,61 @@
+import React, { useReducer, useEffect, useState } from 'react';
+import * as Styled from './style';
+
+import Header from 'containers/Common/Header';
+import TabBar from 'containers/Project/TabBar';
+import TabContainer from 'containers/Project/TabContainer';
+import Editor from 'containers/Project/Editor';
+import BrowserV1 from 'components/Project/BrowserV1';
+import { SplitPaneContainer } from 'components/Common/SplitPane';
+
+import ProjectReducer from 'reducers/ProjectReducer';
+import ProjectContext from 'contexts/ProjectContext';
+import { fetchProjectActionCreator } from 'actions/Project';
+
+import { TAB_BAR_THEME } from 'constants/theme';
+
+const DEFAULT_CLICKED_TAB_INDEX = 0;
+
+function Project() {
+	// temp state : custom hook 만들면 대체할 예정
+	const [isFetched, setIsFetched] = useState(false);
+	const [clickedTabIndex, setClickedTabIndex] = useState(
+		DEFAULT_CLICKED_TAB_INDEX
+	);
+	const [project, dispatchProject] = useReducer(ProjectReducer, {});
+
+	const handleFetchProject = () => {
+		const fetchProjectAction = fetchProjectActionCreator();
+		dispatchProject(fetchProjectAction);
+		setIsFetched(true);
+	};
+
+	useEffect(handleFetchProject, []);
+
+	return (
+		<ProjectContext.Provider
+			value={{
+				project,
+				dispatchProject,
+				clickedTabIndex,
+				setClickedTabIndex
+			}}
+		>
+			<Header />
+			{isFetched && (
+				<Styled.Main>
+					<TabBar theme={TAB_BAR_THEME} />
+					<SplitPaneContainer split="vertical" defaultSize="20vw">
+						<TabContainer />
+						<SplitPaneContainer split="vertical" defaultSize="40vw">
+							<Editor />
+							<BrowserV1 code={project.code} id="coconut-root" />
+						</SplitPaneContainer>
+					</SplitPaneContainer>
+				</Styled.Main>
+			)}
+		</ProjectContext.Provider>
+	);
+}
+
+export default Project;

--- a/cocode/src/utils/addWheelEvent.js
+++ b/cocode/src/utils/addWheelEvent.js
@@ -1,0 +1,18 @@
+let scroll = false;
+
+function handleWheelScroll(e) {
+	if (scroll) return;
+	scroll = true;
+	if (e.deltaY < 0) window.scrollBy(0, -window.innerHeight);
+	else window.scrollBy(0, window.innerHeight);
+	wheelTimer = setTimeout(handleWheelAble, 1000);
+}
+function handleWheelAble() {
+	scroll = false;
+}
+
+function addWheelEvent() {
+	window.addEventListener('wheel', handleWheelScroll);
+}
+
+export default addWheelEvent;


### PR DESCRIPTION
## 간단한 요약 설명
안녕하세요 리뷰어님 ! 저는 **4조 cocode**의 우혜주입니다 :)
지난 주 꼼꼼한 리뷰 너무너무 감사드립니다 ! ❤️
저희 팀은 **codeSandbox** 서비스를 `클론` 한 프로젝트로, **웹 상에서 작동되는 ide**를 구현하려고 합니다!
제가 이번 주에 리뷰어님께 요청하고 싶은 부분은 크게 세 개입니다.

1. 메인 페이지를 스크롤 했을 때 한 페이지씩 스크롤되는 기능을 구현하고자 합니다. 
![](https://media.giphy.com/media/ftkgvuK9NsWhs7IUVc/giphy.gif)

2. 드롭다운의 대시보드 버튼을 클릭하면 대시보드 페이지로 이동하고자 합니다.
![](https://media.giphy.com/media/dtHxpQwWHkmvamTbmG/giphy.gif)

3. 왼쪽 탭바의 각 아이콘들을 클릭하면 아이콘에 해당하는 탭 컨테이너가 노출되고자 합니다.
![](https://media.giphy.com/media/eNjo5yaJ4wD7dYE62E/giphy.gif)

## 질문 사항
#### 메인 페이지를 스크롤하면 한 페이지씩 스크롤된다

초기에 제가 작성했던 방법은 [다음](https://github.com/connect-foundation/2019-04/blob/bbe9ec505b11190dc9f05a11b80988da11a38090/cocode/src/utils/addWheelEvent.js)과 같았습니다. 이후 팀원들과 이야기를 하며 리팩토링하고, 동작 방식을 약간 변경한 결과 [다음](https://github.com/connect-foundation/2019-04/blob/5bc5f8477a508f978147a2ccc9fdbb1c02a3e4a8/cocode/src/utils/addWheelEvent.js)과 같이 수정되었습니다. 처음 사용했던 방식에서는 개발자 도구를 켠 상태에서는 잘 동작하지만 개발자 도구를 끈 상태에서는 원활하게 동작하지 않는 버그가 생겼고, 이를 개선하고자 수정하다가 작동원리를 조금 수정하여 현재 코드리뷰에 올리는 파일과 같이 수정하였습니다.

현재 사용하는 방식은 마우스 휠 이벤트가 처음 발생했을 때 휠의 방향에 따라 스크롤 방향을 상/하로 구분하여 한 페이지씩 이동시키고, `setTimeout` 을 사용하여 1초 후에 다시 이벤트가 작동되도록 구현했습니다. 한번 들어온 휠의 이벤트를 처리하기 전까지는 그 이후에 들어온 이벤트에 대한 처리를 막고자 플래그를 사용했고, 이벤트가 끝나는 시점을 알아내기가 어려워, 1초라는 임의의 시간을 기준으로 휠 이벤트의 끝을 처리했습니다. 임의로 정한 1초라는 시간이 끝나고 난 후 다시 플래그를 변경시켜 이벤트를 처리해주는 방식을 사용하여 구현했습니다.

요즘 마우스 휠에 대한 이벤트로 한 페이지씩 이동시키는 것이 트렌드라고 생각하여 저희 페이지에도 접목시켰는데, 위와 같은 방식이 좋은 방식인지 궁금합니다. 또한 보통 위와 같은 기능을 어떠한 식으로 구현하는지 궁금합니다.


#### #45 대시보드 버튼을 클릭하면 대시보드 페이지로 이동한다

현재 저희가 사용하는 프론트 프레임워크는 리액트이며, 리액트는 기본적으로 리액트 라우터를 제공하고 있습니다. 버튼을 클릭해서 페이지를 이동하는 경우에는 보통 `react-router-dom`의 `Link`를 사용하여 페이지를 이동시켰습니다. 드롭다운 버튼 또한 다른 페이지로 이동해야하는 경우가 있는데, 드롭다운 버튼 클릭 이벤트는 [다음](https://github.com/connect-foundation/2019-04/compare/review...review_hzoou?expand=1#diff-18d982d9d0de5075af1b819a071e702eR28)과 같이 콜백으로 처리되고있습니다.

콜백 내에서 페이지를 이동시키는 방법은 `window.location`을 사용하는 방법밖에 떠오르지 않아, 그 방법으로 해당 페이지로 이동하도록 구현하였습니다. 현재 코코드 프로젝트에서 최대로 길게 나올수 있는 url은 `/a/b` 까지 밖에 없어 `../dashboard/` 로 이동을 시키면 항상 `/dashboard` 페이지로 이동을 할 수 있는데, 만약 `/a/b/c` 와 같이 경로가 한단계 더 깊어진 경우 위와 같은 방식으로는 `/a/dashboard`가 되어버립니다.

위와 같은 상황에서 다른 경로로 이동하기에 가장 좋은 방법을 찾지 못해 임시방편으로 `window.location`을 사용하였으나, 그 방법도 사실상 허점이 많아 어떤 방식으로 구현해야할지 고민이 됩니다. `window.location`을 사용하는 것 말고 더 좋은 방법이 있을지, 상대 경로를 사용한 위와 같은 방식이 아니라 `window.location`으로 절대경로로 이동시키도록 하는 것은 어떨지 궁금합니다.

#### #159 분리되어있는 탭 컨테이너와 탭바를 연동한다

해당 페이지는 네개의 탭이 있는 탭바가 있고, 해당 탭에 따라 뷰가 바뀌어야하는 탭 컨테이너가 존재하는 구조로 이루어져있습니다. 네개의 탭이 있으니, 각각 네개의 컨테이너가 존재하고 (아직 컨테이너 하나는 UI 구현을 하지 못했습니다.) 저는 그 네개의 컨테이너를 담을 공간이 필요하다고 판단하여, 탭 컨테이너라는 컴포넌트를 만들었습니다. 

해당 페이지에서 현재 `clickedTabIndex` 상태를 관리하고 있고, 탭을 클릭할 때마다 탭 바에서 `clickedTabIndex` 값을 변경시켜줍니다. 탭 컨테이너에서는 `clickedTabIndex` 값에 따라 렌더링할 컨테이너들을 [맵핑](https://github.com/connect-foundation/2019-04/compare/review...review_hzoou?expand=1#diff-875330d130ecd76d4c7c7e5cd58930ffR13)해놓고 뿌려주는 방식으로 구현했습니다. 그리고 `useEffect`를 사용하여 `clickedTabIndex` 값이 변경될 때마다 맵핑하여 뿌려주는 함수를 실행시켜 바로바로 변경될 수 있도록 코드를 짰습니다.

위와 같은 방식으로 해당 기능을 구현하는 것이 좋을까요? 혹시 더 좋은 방법이 있을지 궁금합니다.

---
소중한 시간을 내어주셔서 감사합니다 :)