### PR TITLE
파일 탭바에 상태 적용

### DIFF
--- a/cocode/src/components/Project/FileTab/index.js
+++ b/cocode/src/components/Project/FileTab/index.js
@@ -7,7 +7,7 @@ function FileTab({
 	FileName,
 	icon,
 	type,
-	className,
+	clicked,
 	onClick,
 	onCloseClick
 }) {
@@ -15,10 +15,15 @@ function FileTab({
 	const handleCloseClick = () => onCloseClick(index);
 
 	return (
-		<Styled.Tab onClick={handleTabClick} className={className}>
+		<Styled.Tab onClick={handleTabClick} clicked={clicked}>
 			<Styled.Icon src={icon} alt={type} />
 			{FileName}
-			<Styled.Close src={Close} alt="close" onClick={handleCloseClick} />
+			<Styled.Close
+				src={Close}
+				alt="close"
+				clicked={clicked}
+				onClick={handleCloseClick}
+			/>
 		</Styled.Tab>
 	);
 }

--- a/cocode/src/components/Project/FileTab/index.js
+++ b/cocode/src/components/Project/FileTab/index.js
@@ -12,7 +12,7 @@ function FileTab({
 	onCloseClick
 }) {
 	const handleTabClick = () => onClick(index);
-	const handleCloseClick = () => onCloseClick(index);
+	const handleCloseClick = (e) => onCloseClick(e, index);
 
 	return (
 		<Styled.Tab onClick={handleTabClick} clicked={clicked}>

--- a/cocode/src/components/Project/FileTab/style.js
+++ b/cocode/src/components/Project/FileTab/style.js
@@ -1,40 +1,41 @@
 import styled from 'styled-components';
-
-//TODO 나중에 테마로 분리할 계획입니다.
-const EDITOR_DARK_COLOR = '#111518';
+import { FILE_TAB_THEME } from 'constants/theme';
 
 const Tab = styled.li`
-    & {
-        padding: 0.8rem;
-        display: inline-flex;
-        background-color: ${EDITOR_DARK_COLOR};
-        font-size: 0.8rem;
-        cursor: pointer;
-    }
-    
-    &:hover {
-      & > img {
-        visibility: visible;
-      }
-    }
+	& {
+		padding: 0.8rem;
+		display: inline-flex;
+		background-color: ${({ clicked }) =>
+			clicked
+				? FILE_TAB_THEME.fileTabClickedBGColor
+				: FILE_TAB_THEME.fileTabDefaultBGColor};
+		font-size: ${FILE_TAB_THEME.fileTabFontSize};
+		cursor: pointer;
+	}
+
+	&:hover {
+		& > img {
+			visibility: visible;
+		}
+	}
 `;
 
 const Icon = styled.img`
-    & {
-        width: 1.2rem;
-        height: 1.2rem;
-        margin-right: 0.3rem;
-    }
+	& {
+		width: 1.2rem;
+		height: 1.2rem;
+		margin-right: 0.3rem;
+	}
 `;
 
 const Close = styled.img`
-    & {
-        width: 0.8rem;
-        height: 0.8rem;
-        margin-top: 0.18rem;
-        margin-left: 0.5rem;
-        visibility: hidden;
-    }
+	& {
+		width: ${FILE_TAB_THEME.fileTabCloseButtonSize};
+		height: ${FILE_TAB_THEME.fileTabCloseButtonSize};
+		margin-top: 0.18rem;
+		margin-left: 0.5rem;
+		visibility: ${({ clicked }) => (clicked ? 'visible' : 'hidden')};
+	}
 `;
 
 export { Icon, Tab, Close };

--- a/cocode/src/components/Project/FileTabBar/index.js
+++ b/cocode/src/components/Project/FileTabBar/index.js
@@ -21,8 +21,12 @@ function FileTabBar() {
 		openFile.path === files[selectedFilePath].path;
 
 	const handleSetClickedIndex = index => setClickedIndex(index);
-	const handleCloseFile = index =>
-		setOpenFiles(openFiles.filter((file, i) => i !== index));
+	const handleCloseFile = (e, index) => {
+		if (index === openFiles.length - 1 && index) setClickedIndex(index - 1);
+		if (openFiles.length !== 1)
+			setOpenFiles(openFiles.filter((file, i) => i !== index));
+		e.stopPropagation();
+	};
 
 	const addOpenedFile = () => {
 		const currentIdx = openFiles.findIndex(FiledIndex);
@@ -42,11 +46,13 @@ function FileTabBar() {
 				selectedFilePath: openFiles[clickedIndex].path
 			});
 			dispatchProject(selectFileAction);
+		} else if (openFiles[clickedIndex - 1]) {
+			setClickedIndex(clickedIndex - 1);
 		}
 	};
 
 	useEffect(addOpenedFile, [files[selectedFilePath].path]);
-	useEffect(setOpenedFile, [clickedIndex]);
+	useEffect(setOpenedFile, [clickedIndex, openFiles]);
 
 	// TODO icon 컨텍스트에서 관리하는 것으로 수정 필요
 	const icon = FileImagesSrc[files[selectedFilePath].type];

--- a/cocode/src/components/Project/FileTabBar/index.js
+++ b/cocode/src/components/Project/FileTabBar/index.js
@@ -5,11 +5,12 @@ import FileTab from '../FileTab';
 import FileImagesSrc from 'constants/fileImagesSrc';
 
 import ProjectContext from 'contexts/ProjectContext';
+import { selectFileActionCreator } from 'actions/Project';
 
 const DEFAULT_OPENED_FILE_INDEX = 0;
 
 function FileTabBar() {
-	const { project } = useContext(ProjectContext);
+	const { project, dispatchProject } = useContext(ProjectContext);
 	const { files, selectedFilePath } = project;
 
 	const [clickedIndex, setClickedIndex] = useState(DEFAULT_OPENED_FILE_INDEX);
@@ -35,7 +36,17 @@ function FileTabBar() {
 		setClickedIndex(clickedIdx);
 	};
 
+	const setOpenedFile = () => {
+		if (openFiles[clickedIndex]) {
+			const selectFileAction = selectFileActionCreator({
+				selectedFilePath: openFiles[clickedIndex].path
+			});
+			dispatchProject(selectFileAction);
+		}
+	};
+
 	useEffect(addOpenedFile, [files[selectedFilePath].path]);
+	useEffect(setOpenedFile, [clickedIndex]);
 
 	// TODO icon 컨텍스트에서 관리하는 것으로 수정 필요
 	const icon = FileImagesSrc[files[selectedFilePath].type];

--- a/cocode/src/components/Project/FileTabBar/index.js
+++ b/cocode/src/components/Project/FileTabBar/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import * as Styled from './style';
 import FileTab from '../FileTab';
 
@@ -8,19 +8,36 @@ import ProjectContext from 'contexts/ProjectContext';
 
 const DEFAULT_OPENED_FILE_INDEX = 0;
 
-// TODO: 현재 하나의 파일만 바뀌어주는 것만 구현되어 있음. 추후에 파일 리스트에서 하도록 변경 필요.
 function FileTabBar() {
 	const { project } = useContext(ProjectContext);
 	const { files, selectedFilePath } = project;
 
 	const [clickedIndex, setClickedIndex] = useState(DEFAULT_OPENED_FILE_INDEX);
-	//TODO 현재 더미데이터 fileList를 넣은 값으로, 추후 props에서 넘겨온 openFileList가 초기값이 될 예정입니다.
-	const [openFiles, setOpenFiles] = useState([selectedFilePath]);
+	const [openFiles, setOpenFiles] = useState([]);
+
+	const isExistFile = idx => idx !== -1;
+	const FiledIndex = openFile =>
+		openFile.path === files[selectedFilePath].path;
 
 	const handleSetClickedIndex = index => setClickedIndex(index);
 	const handleCloseFile = index =>
 		setOpenFiles(openFiles.filter((file, i) => i !== index));
 
+	const addOpenedFile = () => {
+		const currentIdx = openFiles.findIndex(FiledIndex);
+		const newOpenedFiles = isExistFile(currentIdx)
+			? openFiles
+			: openFiles.concat(files[selectedFilePath]);
+		const clickedIdx = isExistFile(currentIdx)
+			? currentIdx
+			: openFiles.length;
+		setOpenFiles(newOpenedFiles);
+		setClickedIndex(clickedIdx);
+	};
+
+	useEffect(addOpenedFile, [files[selectedFilePath].path]);
+
+	// TODO icon 컨텍스트에서 관리하는 것으로 수정 필요
 	const icon = FileImagesSrc[files[selectedFilePath].type];
 	return (
 		<Styled.TabBar>

--- a/cocode/src/components/Project/FileTabBar/index.js
+++ b/cocode/src/components/Project/FileTabBar/index.js
@@ -24,15 +24,20 @@ function FileTabBar() {
 	const icon = FileImagesSrc[files[selectedFilePath].type];
 	return (
 		<Styled.TabBar>
-			<FileTab
-				index={DEFAULT_OPENED_FILE_INDEX}
-				FileName={files[selectedFilePath].name}
-				icon={icon}
-				type={files[selectedFilePath].type}
-				className={'clicked'}
-				onClick={handleSetClickedIndex}
-				onCloseClick={handleCloseFile}
-			/>
+			{openFiles.map((openFile, index) => {
+				return (
+					<FileTab
+						key={'openFile' + index}
+						index={index}
+						FileName={openFile.name}
+						icon={icon}
+						type={openFile.type}
+						clicked={clickedIndex === index}
+						onClick={handleSetClickedIndex}
+						onCloseClick={handleCloseFile}
+					/>
+				);
+			})}
 		</Styled.TabBar>
 	);
 }

--- a/cocode/src/components/Project/FileTabBar/style.js
+++ b/cocode/src/components/Project/FileTabBar/style.js
@@ -1,8 +1,5 @@
 import styled from 'styled-components';
-
-//TODO 나중에 테마로 분리할 계획입니다.
-const EDITOR_MAIN_COLOR = '#1E2022';
-const EDITOR_DARK_COLOR = '#111518';
+import { FILE_TAB_THEME} from 'constants/theme';
 
 const TabBar = styled.ul`
     & {
@@ -11,15 +8,7 @@ const TabBar = styled.ul`
         display: inline-flex;
         overflow: scroll;
         min-height: 3.1rem;
-        background-color: ${EDITOR_DARK_COLOR};
-    }
-    
-    .clicked {
-        background-color: ${EDITOR_MAIN_COLOR};
-        
-        & > img {
-          visibility: visible;
-        }
+        background-color: ${FILE_TAB_THEME.fileTabDefaultBGColor};
     }
 `;
 

--- a/cocode/src/constants/theme.js
+++ b/cocode/src/constants/theme.js
@@ -94,6 +94,13 @@ const INFO_TAB_THEME = {
 	infoProjectAuthorFontSize: '1.2rem'
 };
 
+const FILE_TAB_THEME = {
+	fileTabDefaultBGColor: '#111518',
+	fileTabClickedBGColor: '#1E2022',
+	fileTabFontSize: '0.8rem',
+	fileTabCloseButtonSize: '0.8rem'
+};
+
 export {
 	DEFAULT_THEME,
 	DROPDOWN_THEME,
@@ -103,5 +110,6 @@ export {
 	PROJECT_CARD_THEME,
 	DEPENDENCY_TAB_THEME,
 	INFO_TAB_THEME,
-	EXPLORER_TAB_CONTAINER_THEME
+	EXPLORER_TAB_CONTAINER_THEME,
+	FILE_TAB_THEME
 };


### PR DESCRIPTION
## 간단한 요약 설명
탐색기 탭에서 클릭한 파일을 파일 탭바에 추가했으며 이미 추가된 파일은 중복으로 추가되지 않도록 했습니다.
파일 탭을 클릭하면 하단 에디터에 해당 파일의 코드를 노출했으며 탐색기 탭에서도 선택되게 구현 했습니다.
파일 탭을 닫는 경우에 해당 인덱스에 따라 이전/이후의 파일탭의 코드를 에디터에 노출하도록 구현했습니다.
파일 탭바에 하나의 파일만 있는 경우 (일단은) 닫기지 않도록 구현했으며, 
이 부분에 대해서는 추가적인 논의가 필요할 것 같습니다.

또한 파일 탭바에서 노출되는 아이콘의 경우에도 파일네임, 코드 등과 같이 프로젝트 컨텍스트에서 관리하는 것이 좋을것 같다는 생각이 들었는데 이 부분에 대해서도 논의가 필요할 것 같습니다.
현재 그 부분은 따로 처리하지않았으며, 지금은 열려있는 파일 확장자에 따라 파일탭바에 전체적인 아이콘이 변경되는 상태입니다.
이 부분은 컨텍스트에서 해당 상태를 관리하는 것에 대한 논의 후에 추후 변경할 계획입니다.

## 관련 이슈
* close #183 