### PR TITLE
대시보드 영역에 스크롤 속성 추가

### DIFF
--- a/cocode/src/containers/DashBoard/ProjectCardList/style.js
+++ b/cocode/src/containers/DashBoard/ProjectCardList/style.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 const Main = styled.main`
+	height: 100%;
 	padding: 3rem;
 `;
 
@@ -9,6 +10,7 @@ const Title = styled.h2`
 	font-size: 2.5rem;
 	font-weight: 300;
 	padding-left: 3.5rem;
+	padding-bottom: 1rem;
 `;
 
 const CoconutCount = styled.span`
@@ -22,12 +24,13 @@ const CardList = styled.section`
 		flex-flow: row wrap;
 		align-content: flex-start;
 		justify-content: flex-start;
-
-		width: 100vw;
-		padding: 0;
+		height: 80%;
+		width: 100%;
+		padding-bottom: 3rem;
+		overflow: auto;
 	}
 	& > * {
-		margin: 3.5rem;
+		margin: 3rem;
 	}
 `;
 


### PR DESCRIPTION
## 간단한 요약 설명
프로젝트 목록을 노출하는 대시보드에서 프로젝트 목록이 많아 영역을 벗어난 경우에도
하위 항목들을 확인할 수 있도록 스크롤 속성을 추가했습니다.

## 관련 이슈
* close #184