### PR TITLE
로그인시 user 데이터를 db에 조회 또는 생성

### DIFF
--- a/api-server/database/seeds/user.seed.js
+++ b/api-server/database/seeds/user.seed.js
@@ -1,22 +1,22 @@
 const mock = [
 	{
 		_id: '5ddbc8d44ee9665d2649b35c',
-		usename: 'basiltoast',
+		username: 'basiltoast',
 		projectIds: ['5ddbc7db8eb1b85c55a84b17']
 	},
 	{
 		_id: '5ddbc974ea2c155dbbb33b49',
-		usename: 'hzoou',
+		username: 'hzoou',
 		projectIds: ['5ddbc9417010185d942569cc']
 	},
 	{
 		_id: '5ddbc7db8eb1b85c55a84b10',
-		usename: 'yukjisoo',
+		username: 'yukjisoo',
 		projectIds: ['5dd61901353f4858e1b5a9d0']
 	},
 	{
 		_id: '5ddbc7db8eb1b85c55a84b11',
-		usename: 'lallaheeee',
+		username: 'lallaheeee',
 		projectIds: ['5ddbc7db8eb1b85c55a84b17']
 	}
 ];

--- a/api-server/src/app.js
+++ b/api-server/src/app.js
@@ -14,8 +14,6 @@ db.on('error', console.error.bind(console, 'connection error:'));
 db.once('open', () => console.log('connected to Mongo'));
 
 mongoose.connect(DATABASE_URI, MONGO_OPTION);
-mongoose.set('useCreateIndex', true);
-mongoose.set('useFindAndModify', false);
 
 app.use(morgan('dev'));
 app.use(cors(CORS_OPTION));

--- a/api-server/src/app.js
+++ b/api-server/src/app.js
@@ -14,6 +14,8 @@ db.on('error', console.error.bind(console, 'connection error:'));
 db.once('open', () => console.log('connected to Mongo'));
 
 mongoose.connect(DATABASE_URI, MONGO_OPTION);
+mongoose.set('useCreateIndex', true);
+mongoose.set('useFindAndModify', false);
 
 app.use(morgan('dev'));
 app.use(cors(CORS_OPTION));

--- a/api-server/src/config/index.js
+++ b/api-server/src/config/index.js
@@ -15,6 +15,7 @@ const DATABASE_URI =
 		? process.env.PROD_DATABASE_URI
 		: process.env.DEV_DATABASE_URI;
 console.log(process.env.NODE_ENV);
+
 const COCODE_CLIENT_URI =
 	process.env.NODE_ENV === 'production'
 		? process.env.PROD_COCODE_CLIENT_URI
@@ -28,7 +29,9 @@ const CORS_OPTION = {
 
 const MONGO_OPTION = {
 	useNewUrlParser: true,
-	useUnifiedTopology: true
+	useUnifiedTopology: true,
+	useCreateIndex: true,
+	useFindAndModify: false
 };
 
 export {

--- a/api-server/src/middlewares/passport.js
+++ b/api-server/src/middlewares/passport.js
@@ -1,29 +1,40 @@
 import dotenv from 'dotenv';
 import passport from 'passport';
+import { User } from '../models';
 import { Strategy as GitHubStrategy } from 'passport-github';
 
 dotenv.config();
 
 const clientOption = {
-    clientID: process.env.GITHUB_CLIENT_ID,
-    clientSecret: process.env.GITHUB_CLIENT_SECRET,
-    callbackURL: process.env.GITHUB_REDIRECT_URI
+	clientID: process.env.GITHUB_CLIENT_ID,
+	clientSecret: process.env.GITHUB_CLIENT_SECRET,
+	callbackURL: process.env.GITHUB_REDIRECT_URI
 };
 
 passport.serializeUser((user, done) => {
-    done(null, user);
+	done(null, user);
 });
 
 passport.deserializeUser((user, done) => {
-    done(null, user);
+	done(null, user);
 });
 
 passport.use(
-    new GitHubStrategy(clientOption, (accessToken, _, profile, done) => {
-            //TODO 넘어온 user profile 정보 db 처리 필요
-            return done(null, profile);
-        }
-    )
+	new GitHubStrategy(clientOption, (accessToken, _, profile, done) => {
+		User.findOneAndUpdate(
+			{ username: profile.username },
+			{ $set: { username: profile.username } },
+			{ upsert: true }
+		).then(data => {
+			const user = {
+				username: data.username,
+				avatar: profile.photos[0].value
+			};
+			return done(null, user);
+		}).catch(() => {
+			return done(null, null);
+		});
+	})
 );
 
 export default passport;

--- a/api-server/src/routes/users/login/controller.js
+++ b/api-server/src/routes/users/login/controller.js
@@ -10,8 +10,8 @@ function loginByGithub(req, res, next) {
 	passport.authenticate(STRATEGY)(req, res, next);
 }
 
-function publishToken({ user: { username, photos } }, res) {
-	const payload = { username: username, avatar: photos[0].value };
+function publishToken({ user: { username, avatar } }, res) {
+	const payload = { username, avatar };
 	const expiresIn = { expiresIn: '7d' };
 	const token = jwt.sign(payload, JWT_SECRET, expiresIn);
 	res.cookie(KEY_JWT, token).redirect(COCODE_CLIENT_URI);


### PR DESCRIPTION
## 간단한 요약 설명
user seed 데이터의 오타를 수정했습니다.
로그인시 github oatuh를 통해 넘어온 user data를 db에 조회하고, 해당 데이터가 없으면 생성하였습니다.

app.js에서 추가한 

```js
mongoose.set('useCreateIndex', true);
```
는
```
DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead.
```
다음과 같은 warning을 해결하기 위해 넣었으며,

```js
mongoose.set('useFindAndModify', false);
```
는
```
DeprecationWarning: Mongoose: `findOneAndUpdate()` and `findOneAndDelete()`
without the `useFindAndModify` option set to false are deprecated.
```
다음과 같은 warning을 해결하기 위해 넣었습니다.

## 관련 이슈
* close #132