### PR TITLE
탐색기 탭에서 파일 삭제 기능 구현

### DIFF
--- a/cocode/src/actions/Project.js
+++ b/cocode/src/actions/Project.js
@@ -3,7 +3,8 @@ import {
 	FETCH_PROJECT,
 	SELECT_FILE,
 	UPDATE_FILE_NAME,
-	CREATE_FILE
+	CREATE_FILE,
+	DELETE_FILE
 } from './types';
 
 function fetchProjectActionCreator(payload) {
@@ -26,10 +27,15 @@ function createFileActionCreator(payload) {
 	return { type: CREATE_FILE, payload };
 }
 
+function deleteFileActionCreator(payload) {
+	return { type: DELETE_FILE, payload };
+}
+
 export {
 	updateCodeActionCreator,
 	fetchProjectActionCreator,
 	selectFileActionCreator,
 	updateFileNameActionCreator,
-	createFileActionCreator
+	createFileActionCreator,
+	deleteFileActionCreator
 };

--- a/cocode/src/actions/types.js
+++ b/cocode/src/actions/types.js
@@ -9,6 +9,7 @@ const FETCH_PROJECT = 'fetchProject';
 const SELECT_FILE = 'selectFile';
 const CREATE_FILE = 'createFile';
 const UPDATE_FILE_NAME = 'updateFileName';
+const DELETE_FILE = 'deleteFile';
 
 export {
 	API_LOADING,
@@ -18,5 +19,6 @@ export {
 	FETCH_PROJECT,
 	SELECT_FILE,
 	UPDATE_FILE_NAME,
-	CREATE_FILE
+	CREATE_FILE,
+	DELETE_FILE
 };

--- a/cocode/src/components/Project/Directory/index.js
+++ b/cocode/src/components/Project/Directory/index.js
@@ -5,6 +5,20 @@ import NewFile from 'components/Project/NewFile';
 
 import ProjectContext from 'contexts/ProjectContext';
 
+// src 디렉토리의 index.js, src 디렉토리, package.json은 삭제불가
+function isProtectedFile({ files, root, entry, fileId }) {
+	if (fileId === entry) return true;
+
+	const entryParentId = files[entry].parentId;
+	if (fileId === entryParentId) return true;
+
+	const fileName = files[fileId].name;
+	const fileParentId = files[fileId].parentId;
+	if (fileName === 'package.json' && fileParentId === root) return true;
+
+	return false;
+}
+
 function Directory({
 	id,
 	path,
@@ -15,7 +29,7 @@ function Directory({
 	...props
 }) {
 	const {
-		project: { files, selectedFileId }
+		project: { files, root, entry, selectedFileId }
 	} = useContext(ProjectContext);
 	const [isNewFileCreating, setIsNewFileCreating] = useState(false);
 	const [createFileType, setCreateFileType] = useState(null);
@@ -50,6 +64,12 @@ function Directory({
 			isNotRoot(depth) && (
 				<File
 					isDirectory={true}
+					isProtectedFile={isProtectedFile({
+						files,
+						root,
+						entry,
+						fileId: id
+					})}
 					depth={depth - 1}
 					id={id}
 					handleCreateFile={handleCreateFile}
@@ -91,6 +111,12 @@ function Directory({
 					<File
 						key={'file' + _id}
 						id={_id}
+						isProtectedFile={isProtectedFile({
+							files,
+							root,
+							entry,
+							fileId: _id
+						})}
 						isDirectory={false}
 						className={isSelected(_id) && 'Is-selected-file'}
 						depth={depth}

--- a/cocode/src/components/Project/Directory/index.js
+++ b/cocode/src/components/Project/Directory/index.js
@@ -5,7 +5,15 @@ import NewFile from 'components/Project/NewFile';
 
 import ProjectContext from 'contexts/ProjectContext';
 
-function Directory({ id, path, childIds, depth, handleSelectFile, ...props }) {
+function Directory({
+	id,
+	path,
+	childIds,
+	depth,
+	handleSelectFile,
+	handleDeleteFile,
+	...props
+}) {
 	const {
 		project: { files, selectedFileId }
 	} = useContext(ProjectContext);
@@ -46,6 +54,7 @@ function Directory({ id, path, childIds, depth, handleSelectFile, ...props }) {
 					id={id}
 					handleCreateFile={handleCreateFile}
 					handleEditFileName={handleEditFileName}
+					handleDeleteFile={handleDeleteFile}
 					{...files[id]}
 				/>
 			)}
@@ -59,6 +68,7 @@ function Directory({ id, path, childIds, depth, handleSelectFile, ...props }) {
 						depth={depth + 1}
 						handleSelectFile={handleSelectFile}
 						handleEditFileName={props.handleEditFileName}
+						handleDeleteFile={handleDeleteFile}
 					/>
 				);
 			})}
@@ -87,6 +97,7 @@ function Directory({ id, path, childIds, depth, handleSelectFile, ...props }) {
 						handleEditFileName={handleEditFileName}
 						handleSelectFile={handleSelectFile}
 						handleCreateFile={handleCreateFile}
+						handleDeleteFile={handleDeleteFile}
 						{...files[_id]}
 					/>
 				);

--- a/cocode/src/components/Project/File/index.js
+++ b/cocode/src/components/Project/File/index.js
@@ -21,6 +21,7 @@ const ACCEPT_DELETE_NOTIFICATION = '이 파일을 지우시겠습니까?';
 
 function File({
 	isDirectory,
+	isProtectedFile,
 	_id,
 	type,
 	name,
@@ -36,23 +37,39 @@ function File({
 	const nameEditReferenece = useRef(null);
 
 	// Event handlers
+	const noticeThieFileIsProtected = () => {
+		const WARNING_PREVENT_NOTIFICATION =
+			'해당 파일은 이름을 변경하거나 삭제할 수 없습니다.';
+		alert(WARNING_PREVENT_NOTIFICATION);
+	};
 	const handleClick = () => handleSelectFile(_id);
 
-	const handleEditFileNameStart = () => {
+	const handleEditFileNameStart = e => {
+		e.stopPropagation();
+
+		if (isProtectedFile) {
+			noticeThieFileIsProtected();
+			return;
+		}
+
 		changeDivEditable(nameEditReferenece.current, true);
 		setToggleEdit(true);
 	};
 
 	const handleEditFileNameEnd = ({ currentTarget }) => {
+		setToggleEdit(false);
+		nameEditReferenece.current.contentEditable = false;
 		const changedName = currentTarget.textContent;
 		setFileName(changedName);
 		handleEditFileName(changedName);
-
-		setToggleEdit(false);
-		nameEditReferenece.current.contentEditable = false;
 	};
 
 	const handleDeleteFileButtonClick = e => {
+		if (isProtectedFile) {
+			noticeThieFileIsProtected();
+			return;
+		}
+
 		const acceptDeleteThisFile = confirm(ACCEPT_DELETE_NOTIFICATION);
 		if (!acceptDeleteThisFile) return;
 
@@ -61,7 +78,10 @@ function File({
 	};
 
 	const handleKeyDown = e => {
-		if (e.keyCode === KEY_CODE_ENTER) handleEditFileNameEnd(e);
+		if (e.keyCode === KEY_CODE_ENTER) {
+			setToggleEdit(false);
+			nameEditReferenece.current.contentEditable = false;
+		}
 	};
 
 	return (

--- a/cocode/src/components/Project/File/index.js
+++ b/cocode/src/components/Project/File/index.js
@@ -16,6 +16,9 @@ import {
 import FileImagesSrc from 'constants/fileImagesSrc';
 import { KEY_CODE_ENTER } from 'constants/keyCode';
 
+// Constants
+const ACCEPT_DELETE_NOTIFICATION = '이 파일을 지우시겠습니까?';
+
 function File({
 	isDirectory,
 	_id,
@@ -25,6 +28,7 @@ function File({
 	handleSelectFile,
 	handleCreateFile,
 	handleEditFileName,
+	handleDeleteFile,
 	...props
 }) {
 	const [fileName, setFileName] = useState(name);
@@ -46,6 +50,14 @@ function File({
 
 		setToggleEdit(false);
 		nameEditReferenece.current.contentEditable = false;
+	};
+
+	const handleDeleteFileButtonClick = e => {
+		const acceptDeleteThisFile = confirm(ACCEPT_DELETE_NOTIFICATION);
+		if (!acceptDeleteThisFile) return;
+
+		e.stopPropagation();
+		handleDeleteFile(_id);
 	};
 
 	const handleKeyDown = e => {
@@ -83,7 +95,7 @@ function File({
 						/>
 					</>
 				)}
-				<DeleteIcon />
+				<DeleteIcon onClick={handleDeleteFileButtonClick} />
 			</Styled.SideIcons>
 		</Styled.File>
 	);

--- a/cocode/src/components/Project/File/index.js
+++ b/cocode/src/components/Project/File/index.js
@@ -18,6 +18,8 @@ import { KEY_CODE_ENTER } from 'constants/keyCode';
 
 // Constants
 const ACCEPT_DELETE_NOTIFICATION = '이 파일을 지우시겠습니까?';
+const WARNING_PREVENT_NOTIFICATION =
+	'해당 파일은 이름을 변경하거나 삭제할 수 없습니다.';
 
 function File({
 	isDirectory,
@@ -36,21 +38,16 @@ function File({
 	const [toggleEdit, setToggleEdit] = useState(false);
 	const nameEditReferenece = useRef(null);
 
+	// Functions
+	const checkThisFileIsProtected = () =>
+		isProtectedFile && !alert(WARNING_PREVENT_NOTIFICATION);
+
 	// Event handlers
-	const noticeThieFileIsProtected = () => {
-		const WARNING_PREVENT_NOTIFICATION =
-			'해당 파일은 이름을 변경하거나 삭제할 수 없습니다.';
-		alert(WARNING_PREVENT_NOTIFICATION);
-	};
 	const handleClick = () => handleSelectFile(_id);
 
 	const handleEditFileNameStart = e => {
 		e.stopPropagation();
-
-		if (isProtectedFile) {
-			noticeThieFileIsProtected();
-			return;
-		}
+		if (checkThisFileIsProtected()) return;
 
 		changeDivEditable(nameEditReferenece.current, true);
 		setToggleEdit(true);
@@ -65,15 +62,12 @@ function File({
 	};
 
 	const handleDeleteFileButtonClick = e => {
-		if (isProtectedFile) {
-			noticeThieFileIsProtected();
-			return;
-		}
+		e.stopPropagation();
+		if (checkThisFileIsProtected()) return;
 
 		const acceptDeleteThisFile = confirm(ACCEPT_DELETE_NOTIFICATION);
 		if (!acceptDeleteThisFile) return;
 
-		e.stopPropagation();
 		handleDeleteFile(_id);
 	};
 

--- a/cocode/src/components/Project/FileTabBar/index.js
+++ b/cocode/src/components/Project/FileTabBar/index.js
@@ -60,7 +60,9 @@ function FileTabBar() {
 
 	const updateOpenedFile = () => {
 		if (!openFiles.length) return;
-		const newOpenFile = openFiles.map(({ _id }) => files[_id]);
+		const newOpenFile = openFiles
+			.map(({ _id }) => files[_id])
+			.filter(file => file);
 		setOpenFiles(newOpenFile);
 	};
 

--- a/cocode/src/containers/Project/ExplorerTab/index.js
+++ b/cocode/src/containers/Project/ExplorerTab/index.js
@@ -11,7 +11,8 @@ import NewFile from 'components/Project/NewFile';
 import ProjectContext from 'contexts/ProjectContext';
 import {
 	selectFileActionCreator,
-	updateFileNameActionCreator
+	updateFileNameActionCreator,
+	deleteFileActionCreator
 } from 'actions/Project';
 
 const TAB_TITLE = 'EXPLOLER';
@@ -60,6 +61,11 @@ function ExplorerTab() {
 		dispatchProject(updateFileNameAction);
 	};
 
+	const handleDeleteFile = deleteFileId => {
+		const updateFileNameAction = deleteFileActionCreator({ deleteFileId });
+		dispatchProject(updateFileNameAction);
+	};
+
 	return (
 		<>
 			<TabHeader handleCreateFile={handleCreateFile} />
@@ -78,6 +84,7 @@ function ExplorerTab() {
 					depth={1}
 					handleSelectFile={handleSelectFile}
 					handleEditFileName={handleEditFileName}
+					handleDeleteFile={handleDeleteFile}
 				/>
 			</Styled.TabBody>
 		</>

--- a/cocode/src/dummy/Project.js
+++ b/cocode/src/dummy/Project.js
@@ -137,11 +137,7 @@ const project = {
 			_id: '5dd553be4561ae2bae9cb463',
 			name: 'root',
 			type: 'directory',
-			child: [
-				'5dd553be4561ae2bae9cb45f'
-				// '5dd553be4561ae2bae9cb461',
-				// '5dd553be4561ae2bae9cb462'
-			]
+			child: ['5dd553be4561ae2bae9cb45f', '5dd553be4561ae2bae9cb462']
 		},
 		{
 			_id: '5dd553be4561ae2bae9cb45f',
@@ -182,13 +178,13 @@ const project = {
 			type: 'js',
 			contents: getTemplate('Banana'),
 			_id: '5dd553be4561ae2bae9cb460'
+		},
+		{
+			name: 'package.json',
+			type: 'npm',
+			contents: getTemplate('package'),
+			_id: '5dd553be4561ae2bae9cb462'
 		}
-		// {
-		// 	name: 'package.json',
-		// 	type: 'npm',
-		// 	contents: getTemplate('package'),
-		// 	_id: '5dd553be4561ae2bae9cb462'
-		// }
 	]
 };
 

--- a/cocode/src/reducers/ProjectReducer.js
+++ b/cocode/src/reducers/ProjectReducer.js
@@ -172,14 +172,8 @@ function updatePathOfChild(prePath, files, child) {
 }
 
 // Delete file
-const WARNING_NOTIFICATION = '해당 파일은 삭제할 수 없습니다.';
 const deleteFile = (state, { deleteFileId }) => {
-	const { files, entry, root } = state;
-	if (isProtectedFile({ files, root, entry, deleteFileId })) {
-		alert(WARNING_NOTIFICATION);
-		return { ...state };
-	}
-
+	const { files } = state;
 	const { parentId } = files[deleteFileId];
 	const updatedParentChilds = state.files[parentId].child.filter(
 		id => id !== deleteFileId
@@ -197,21 +191,6 @@ const deleteFile = (state, { deleteFileId }) => {
 		}
 	};
 };
-
-// src 디렉토리의 index.js, src 디렉토리, package.json은 삭제불가
-function isProtectedFile({ files, root, entry, deleteFileId }) {
-	if (deleteFileId === entry) return true;
-
-	const entryParentId = files[entry].parentId;
-	if (deleteFileId === entryParentId) return true;
-
-	const deleteFileName = files[deleteFileId].name;
-	const deleteFileParentId = files[deleteFileId].parentId;
-	if (deleteFileName === 'package.json' && deleteFileParentId === root)
-		return true;
-
-	return false;
-}
 
 function ProjectReducer(state, { type, payload }) {
 	const reducers = {

--- a/cocode/src/reducers/ProjectReducer.js
+++ b/cocode/src/reducers/ProjectReducer.js
@@ -129,8 +129,15 @@ const updateFileName = (state, { selectedFileId, changedName }) => {
 	};
 };
 
+const WARNING_NOTIFICATION = '해당 파일은 삭제할 수 없습니다.';
 const deleteFile = (state, { deleteFileId }) => {
-	const { parentId } = state.files[deleteFileId];
+	const { files, entry, root } = state;
+	if (isProtectedFile({ files, root, entry, deleteFileId })) {
+		alert(WARNING_NOTIFICATION);
+		return { ...state };
+	}
+
+	const { parentId } = files[deleteFileId];
 	const updatedParentChilds = state.files[parentId].child.filter(
 		id => id !== deleteFileId
 	);
@@ -147,6 +154,21 @@ const deleteFile = (state, { deleteFileId }) => {
 		}
 	};
 };
+
+// src 디렉토리의 index.js, src 디렉토리, package.json은 삭제불가
+function isProtectedFile({ files, root, entry, deleteFileId }) {
+	if (deleteFileId === entry) return true;
+
+	const entryParentId = files[entry].parentId;
+	if (deleteFileId === entryParentId) return true;
+
+	const deleteFileName = files[deleteFileId].name;
+	const deleteFileParentId = files[deleteFileId].parentId;
+	if (deleteFileName === 'package.json' && deleteFileParentId === root)
+		return true;
+
+	return false;
+}
 
 function ProjectReducer(state, { type, payload }) {
 	const reducers = {

--- a/cocode/src/reducers/ProjectReducer.js
+++ b/cocode/src/reducers/ProjectReducer.js
@@ -4,7 +4,8 @@ import {
 	FETCH_PROJECT,
 	SELECT_FILE,
 	CREATE_FILE,
-	UPDATE_FILE_NAME
+	UPDATE_FILE_NAME,
+	DELETE_FILE
 } from 'actions/types';
 
 import { getFileExtension } from 'utils';
@@ -128,13 +129,33 @@ const updateFileName = (state, { selectedFileId, changedName }) => {
 	};
 };
 
+const deleteFile = (state, { deleteFileId }) => {
+	const { parentId } = state.files[deleteFileId];
+	const updatedParentChilds = state.files[parentId].child.filter(
+		id => id !== deleteFileId
+	);
+
+	return {
+		...state,
+		files: {
+			...state.files,
+			[deleteFileId]: undefined,
+			[parentId]: {
+				...state.files[parentId],
+				child: updatedParentChilds
+			}
+		}
+	};
+};
+
 function ProjectReducer(state, { type, payload }) {
 	const reducers = {
 		[FETCH_PROJECT]: fetchProject,
 		[UPDATE_CODE]: updateCode,
 		[SELECT_FILE]: selectFile,
 		[UPDATE_FILE_NAME]: updateFileName,
-		[CREATE_FILE]: createFile
+		[CREATE_FILE]: createFile,
+		[DELETE_FILE]: deleteFile
 	};
 
 	const reducer = reducers[type];


### PR DESCRIPTION
## 간단한 요약 설명
- 탐색기 탭에서 특정 파일을 삭제 할 수 있습니다.
- 삭제 또는 변경되면 안되는 파일들(package.json, entry file)에 대해서 event가 발생하는 것을 방지했습니다.
- dummy data에 package.json을 추가해주었습니다.

## 관련 이슈
* close #194 