### PR TITLE
탐색기 탭에서 파일 이동기능 구현

### DIFF
--- a/cocode/src/actions/Project.js
+++ b/cocode/src/actions/Project.js
@@ -4,7 +4,8 @@ import {
 	SELECT_FILE,
 	UPDATE_FILE_NAME,
 	CREATE_FILE,
-	DELETE_FILE
+	DELETE_FILE,
+	MOVE_FILE
 } from './types';
 
 function fetchProjectActionCreator(payload) {
@@ -31,11 +32,16 @@ function deleteFileActionCreator(payload) {
 	return { type: DELETE_FILE, payload };
 }
 
+function moveFileActionCreator(payload) {
+	return { type: MOVE_FILE, payload };
+}
+
 export {
 	updateCodeActionCreator,
 	fetchProjectActionCreator,
 	selectFileActionCreator,
 	updateFileNameActionCreator,
 	createFileActionCreator,
-	deleteFileActionCreator
+	deleteFileActionCreator,
+	moveFileActionCreator
 };

--- a/cocode/src/actions/Project.js
+++ b/cocode/src/actions/Project.js
@@ -3,7 +3,8 @@ import {
 	FETCH_PROJECT,
 	SELECT_FILE,
 	UPDATE_FILE_NAME,
-	CREATE_FILE
+	CREATE_FILE,
+	DELETE_FILE
 } from './types';
 
 function fetchProjectActionCreator(payload) {
@@ -26,10 +27,15 @@ function createFileActionCreator(payload) {
 	return { type: CREATE_FILE, payload };
 }
 
+function deleteFileActionCreator(payload) {
+	return { type: DELETE_FILE, payload };
+}
+
 export {
 	updateCodeActionCreator,
 	fetchProjectActionCreator,
 	selectFileActionCreator,
 	updateFileNameActionCreator,
-	createFileActionCreator
+	createFileActionCreator,
+	deleteFileActionCreator
 };

--- a/cocode/src/actions/types.js
+++ b/cocode/src/actions/types.js
@@ -9,6 +9,7 @@ const FETCH_PROJECT = 'fetchProject';
 const SELECT_FILE = 'selectFile';
 const CREATE_FILE = 'createFile';
 const UPDATE_FILE_NAME = 'updateFileName';
+const DELETE_FILE = 'deleteFile';
 
 export {
 	API_LOADING,
@@ -18,5 +19,6 @@ export {
 	FETCH_PROJECT,
 	SELECT_FILE,
 	UPDATE_FILE_NAME,
-	CREATE_FILE
+	CREATE_FILE,
+	DELETE_FILE
 };

--- a/cocode/src/actions/types.js
+++ b/cocode/src/actions/types.js
@@ -10,6 +10,7 @@ const SELECT_FILE = 'selectFile';
 const CREATE_FILE = 'createFile';
 const UPDATE_FILE_NAME = 'updateFileName';
 const DELETE_FILE = 'deleteFile';
+const MOVE_FILE = 'moveFile';
 
 export {
 	API_LOADING,
@@ -20,5 +21,6 @@ export {
 	SELECT_FILE,
 	UPDATE_FILE_NAME,
 	CREATE_FILE,
-	DELETE_FILE
+	DELETE_FILE,
+	MOVE_FILE
 };

--- a/cocode/src/components/Common/DropZone/index.js
+++ b/cocode/src/components/Common/DropZone/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import * as Styled from './style';
+
+function DropZone({ draggableComponentOverColor, ...props }) {
+	const handleDragOver = e => {
+		e.stopPropagation();
+		e.preventDefault();
+		props.handleDragOver();
+	};
+
+	const handleDragLeave = e => {
+		e.stopPropagation();
+		props.handleDragLeave(e);
+	};
+
+	const handleDrop = e => {
+		e.stopPropagation();
+		const data = e.dataTransfer.getData('text');
+		props.handleDrop(data);
+	};
+
+	return (
+		<Styled.DropZone
+			draggableComponentOverColor={draggableComponentOverColor}
+			onDragOver={handleDragOver}
+			onDragLeave={handleDragLeave}
+			onDrop={handleDrop}
+			{...props}
+		></Styled.DropZone>
+	);
+}
+
+export default DropZone;

--- a/cocode/src/components/Common/DropZone/style.js
+++ b/cocode/src/components/Common/DropZone/style.js
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+const DropZone = styled.div`
+	& {
+		background-color: ${({ draggableComponentOverColor }) =>
+			draggableComponentOverColor
+				? draggableComponentOverColor
+				: 'transparent'};
+		height: ${({ height }) => height};
+	}
+`;
+
+export { DropZone };

--- a/cocode/src/components/Project/Directory/index.js
+++ b/cocode/src/components/Project/Directory/index.js
@@ -5,6 +5,20 @@ import NewFile from 'components/Project/NewFile';
 
 import ProjectContext from 'contexts/ProjectContext';
 
+// src 디렉토리의 index.js, src 디렉토리, package.json은 삭제불가
+function isProtectedFile({ files, root, entry, fileId }) {
+	if (fileId === entry) return true;
+
+	const entryParentId = files[entry].parentId;
+	if (fileId === entryParentId) return true;
+
+	const fileName = files[fileId].name;
+	const fileParentId = files[fileId].parentId;
+	if (fileName === 'package.json' && fileParentId === root) return true;
+
+	return false;
+}
+
 function Directory({
 	id,
 	path,
@@ -15,7 +29,7 @@ function Directory({
 	...props
 }) {
 	const {
-		project: { files, selectedFileId }
+		project: { files, root, entry, selectedFileId }
 	} = useContext(ProjectContext);
 	const [isNewFileCreating, setIsNewFileCreating] = useState(false);
 	const [createFileType, setCreateFileType] = useState(null);
@@ -50,6 +64,12 @@ function Directory({
 			isNotRoot(depth) && (
 				<File
 					isDirectory={true}
+					isProtectedFile={isProtectedFile({
+						files,
+						root,
+						entry,
+						fileId: id
+					})}
 					depth={depth - 1}
 					id={id}
 					handleCreateFile={handleCreateFile}
@@ -91,6 +111,12 @@ function Directory({
 					<File
 						key={'file' + _id}
 						id={_id}
+						isProtectedFile={isProtectedFile({
+							files,
+							root,
+							entry,
+							fileId: _id
+						})}
 						isDirectory={false}
 						className={isSelected(_id) && 'Is-selected-file'}
 						depth={depth}

--- a/cocode/src/components/Project/Directory/index.js
+++ b/cocode/src/components/Project/Directory/index.js
@@ -5,7 +5,15 @@ import NewFile from 'components/Project/NewFile';
 
 import ProjectContext from 'contexts/ProjectContext';
 
-function Directory({ id, path, childIds, depth, handleSelectFile, ...props }) {
+function Directory({
+	id,
+	path,
+	childIds,
+	depth,
+	handleSelectFile,
+	handleDeleteFile,
+	...props
+}) {
 	const {
 		project: { files, selectedFileId }
 	} = useContext(ProjectContext);
@@ -46,6 +54,7 @@ function Directory({ id, path, childIds, depth, handleSelectFile, ...props }) {
 					id={id}
 					handleCreateFile={handleCreateFile}
 					handleEditFileName={handleEditFileName}
+					handleDeleteFile={handleDeleteFile}
 					{...files[id]}
 				/>
 			)}
@@ -59,6 +68,7 @@ function Directory({ id, path, childIds, depth, handleSelectFile, ...props }) {
 						depth={depth + 1}
 						handleSelectFile={handleSelectFile}
 						handleEditFileName={props.handleEditFileName}
+						handleDeleteFile={handleDeleteFile}
 					/>
 				);
 			})}
@@ -87,6 +97,7 @@ function Directory({ id, path, childIds, depth, handleSelectFile, ...props }) {
 						handleEditFileName={handleEditFileName}
 						handleSelectFile={handleSelectFile}
 						handleCreateFile={handleCreateFile}
+						handleDeleteFile={handleDeleteFile}
 						{...files[_id]}
 					/>
 				);

--- a/cocode/src/components/Project/Directory/index.js
+++ b/cocode/src/components/Project/Directory/index.js
@@ -1,9 +1,18 @@
 import React, { useState, useContext } from 'react';
 
+import DropZone from 'components/Common/DropZone';
 import File from 'components/Project/File';
 import NewFile from 'components/Project/NewFile';
 
 import ProjectContext from 'contexts/ProjectContext';
+
+import { EXPLORER_TAB_CONTAINER_THEME } from 'constants/theme';
+
+// Constants
+const {
+	explorerTabContainerFileDropZoneOverBGColor,
+	explorerTabContainerFileDropZoneNotOverBGColor
+} = EXPLORER_TAB_CONTAINER_THEME;
 
 // src 디렉토리의 index.js, src 디렉토리, package.json은 삭제불가
 function isProtectedFile({ files, root, entry, fileId }) {
@@ -21,17 +30,18 @@ function isProtectedFile({ files, root, entry, fileId }) {
 
 function Directory({
 	id,
-	path,
 	childIds,
 	depth,
 	handleSelectFile,
 	handleDeleteFile,
+	handleMoveFile,
 	...props
 }) {
 	const {
 		project: { files, root, entry, selectedFileId }
 	} = useContext(ProjectContext);
 	const [isNewFileCreating, setIsNewFileCreating] = useState(false);
+	const [isFileInDropZone, setIsFileInDropZone] = useState(false);
 	const [createFileType, setCreateFileType] = useState(null);
 
 	// Functions
@@ -58,8 +68,27 @@ function Directory({
 	};
 	const handleEndCreateFile = () => setIsNewFileCreating(false);
 
+	const handleDragOver = () => setIsFileInDropZone(true);
+	const handleDragLeave = () => setIsFileInDropZone(false);
+	const handleDrop = fileId => {
+		setIsFileInDropZone(false);
+		if (fileId === id) return;
+		handleMoveFile(id, fileId);
+	};
+
 	return (
-		<div className="DropZone">
+		<DropZone
+			className="DropZone"
+			height={isNotRoot(depth) ? 'auto' : '100%'}
+			draggableComponentOverColor={
+				isFileInDropZone
+					? explorerTabContainerFileDropZoneOverBGColor
+					: explorerTabContainerFileDropZoneNotOverBGColor
+			}
+			handleDragOver={handleDragOver}
+			handleDragLeave={handleDragLeave}
+			handleDrop={handleDrop}
+		>
 			{/* Directory type file */
 			isNotRoot(depth) && (
 				<File
@@ -89,6 +118,7 @@ function Directory({
 						handleSelectFile={handleSelectFile}
 						handleEditFileName={props.handleEditFileName}
 						handleDeleteFile={handleDeleteFile}
+						handleMoveFile={handleMoveFile}
 					/>
 				);
 			})}
@@ -128,7 +158,7 @@ function Directory({
 					/>
 				);
 			})}
-		</div>
+		</DropZone>
 	);
 }
 

--- a/cocode/src/components/Project/Directory/index.js
+++ b/cocode/src/components/Project/Directory/index.js
@@ -13,6 +13,7 @@ const {
 	explorerTabContainerFileDropZoneOverBGColor,
 	explorerTabContainerFileDropZoneNotOverBGColor
 } = EXPLORER_TAB_CONTAINER_THEME;
+const WARNING_PREVENT_MOVE_NOTIFICATION = '해당 파일은 이동시킬 수 없습니다.';
 
 // src 디렉토리의 index.js, src 디렉토리, package.json은 삭제불가
 function isProtectedFile({ files, root, entry, fileId }) {
@@ -72,7 +73,8 @@ function Directory({
 	const handleDragLeave = () => setIsFileInDropZone(false);
 	const handleDrop = fileId => {
 		setIsFileInDropZone(false);
-		if (fileId === id) return;
+		if (fileId === id || isProtectedFile({ files, root, entry, fileId }))
+			return alert(WARNING_PREVENT_MOVE_NOTIFICATION);
 		handleMoveFile(id, fileId);
 	};
 

--- a/cocode/src/components/Project/Directory/index.js
+++ b/cocode/src/components/Project/Directory/index.js
@@ -1,4 +1,5 @@
 import React, { useState, useContext } from 'react';
+import * as Styled from './style';
 
 import DropZone from 'components/Common/DropZone';
 import File from 'components/Project/File';
@@ -43,6 +44,7 @@ function Directory({
 	} = useContext(ProjectContext);
 	const [isNewFileCreating, setIsNewFileCreating] = useState(false);
 	const [isFileInDropZone, setIsFileInDropZone] = useState(false);
+	const [toggleDirectoryOpen, setToggleDirectoryOpen] = useState(depth === 1);
 	const [createFileType, setCreateFileType] = useState(null);
 
 	// Functions
@@ -59,6 +61,8 @@ function Directory({
 	const fileList = childIds ? childIds.map(fileIdToFile).filter(isFile) : [];
 
 	// Evnet handler
+	const handleToggleDirectory = () =>
+		setToggleDirectoryOpen(!toggleDirectoryOpen);
 	const handleEditFileName = changedName => {
 		props.handleEditFileName(id, changedName);
 	};
@@ -95,6 +99,7 @@ function Directory({
 			isNotRoot(depth) && (
 				<File
 					isDirectory={true}
+					isOpened={toggleDirectoryOpen}
 					isProtectedFile={isProtectedFile({
 						files,
 						root,
@@ -103,27 +108,57 @@ function Directory({
 					})}
 					depth={depth - 1}
 					id={id}
+					handleSelectFile={handleToggleDirectory}
 					handleCreateFile={handleCreateFile}
 					handleEditFileName={handleEditFileName}
 					handleDeleteFile={handleDeleteFile}
 					{...files[id]}
 				/>
 			)}
-			{/* 이 Directory에 속한 Directory 목록 */
-			directoryList.map(({ _id }) => {
-				return (
-					<Directory
-						key={'directory_' + _id}
-						id={_id}
-						childIds={files[_id].child}
-						depth={depth + 1}
-						handleSelectFile={handleSelectFile}
-						handleEditFileName={props.handleEditFileName}
-						handleDeleteFile={handleDeleteFile}
-						handleMoveFile={handleMoveFile}
-					/>
-				);
-			})}
+			<Styled.FileList toggle={toggleDirectoryOpen}>
+				{/* 이 Directory에 속한 Directory 목록 */
+				directoryList.map(({ _id }) => {
+					return (
+						<Directory
+							key={'directory_' + _id}
+							id={_id}
+							childIds={files[_id].child}
+							depth={depth + 1}
+							handleSelectFile={handleSelectFile}
+							handleEditFileName={props.handleEditFileName}
+							handleDeleteFile={handleDeleteFile}
+							handleMoveFile={handleMoveFile}
+						/>
+					);
+				})}
+				{/* 이 Directory에 속한 File들 */
+				fileList.map(({ _id }) => {
+					const handleEditFileName = changedName => {
+						props.handleEditFileName(_id, changedName);
+					};
+
+					return (
+						<File
+							key={'file' + _id}
+							id={_id}
+							isProtectedFile={isProtectedFile({
+								files,
+								root,
+								entry,
+								fileId: _id
+							})}
+							isDirectory={false}
+							className={isSelected(_id) && 'Is-selected-file'}
+							depth={depth}
+							handleEditFileName={handleEditFileName}
+							handleSelectFile={handleSelectFile}
+							handleCreateFile={handleCreateFile}
+							handleDeleteFile={handleDeleteFile}
+							{...files[_id]}
+						/>
+					);
+				})}
+			</Styled.FileList>
 			{/* 새파일 생성 버튼 클릭시 나오는 컴포넌트 */
 			isNewFileCreating && (
 				<NewFile
@@ -133,33 +168,6 @@ function Directory({
 					handleEndCreateFile={handleEndCreateFile}
 				/>
 			)}
-			{/* 이 Directory에 속한 File들 */
-			fileList.map(({ _id }) => {
-				const handleEditFileName = changedName => {
-					props.handleEditFileName(_id, changedName);
-				};
-
-				return (
-					<File
-						key={'file' + _id}
-						id={_id}
-						isProtectedFile={isProtectedFile({
-							files,
-							root,
-							entry,
-							fileId: _id
-						})}
-						isDirectory={false}
-						className={isSelected(_id) && 'Is-selected-file'}
-						depth={depth}
-						handleEditFileName={handleEditFileName}
-						handleSelectFile={handleSelectFile}
-						handleCreateFile={handleCreateFile}
-						handleDeleteFile={handleDeleteFile}
-						{...files[_id]}
-					/>
-				);
-			})}
 		</DropZone>
 	);
 }

--- a/cocode/src/components/Project/Directory/style.js
+++ b/cocode/src/components/Project/Directory/style.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const FileList = styled.div`
+	& {
+		display: ${({ toggle }) => (toggle ? 'block' : 'none')};
+	}
+`;
+
+export { FileList };

--- a/cocode/src/components/Project/File/index.js
+++ b/cocode/src/components/Project/File/index.js
@@ -29,7 +29,6 @@ function File({
 	name,
 	depth,
 	handleSelectFile,
-	handleCreateFile,
 	handleEditFileName,
 	handleDeleteFile,
 	...props
@@ -69,6 +68,11 @@ function File({
 		if (!acceptDeleteThisFile) return;
 
 		handleDeleteFile(_id);
+	};
+
+	const handleCreateFile = (type, e) => {
+		e.stopPropagation();
+		props.handleCreateFile(type);
 	};
 
 	const handleKeyDown = e => {

--- a/cocode/src/components/Project/File/index.js
+++ b/cocode/src/components/Project/File/index.js
@@ -21,6 +21,7 @@ const ACCEPT_DELETE_NOTIFICATION = '이 파일을 지우시겠습니까?';
 
 function File({
 	isDirectory,
+	isProtectedFile,
 	_id,
 	type,
 	name,
@@ -36,23 +37,39 @@ function File({
 	const nameEditReferenece = useRef(null);
 
 	// Event handlers
+	const noticeThieFileIsProtected = () => {
+		const WARNING_PREVENT_NOTIFICATION =
+			'해당 파일은 이름을 변경하거나 삭제할 수 없습니다.';
+		alert(WARNING_PREVENT_NOTIFICATION);
+	};
 	const handleClick = () => handleSelectFile(_id);
 
-	const handleEditFileNameStart = () => {
+	const handleEditFileNameStart = e => {
+		e.stopPropagation();
+
+		if (isProtectedFile) {
+			noticeThieFileIsProtected();
+			return;
+		}
+
 		changeDivEditable(nameEditReferenece.current, true);
 		setToggleEdit(true);
 	};
 
 	const handleEditFileNameEnd = ({ currentTarget }) => {
+		setToggleEdit(false);
+		nameEditReferenece.current.contentEditable = false;
 		const changedName = currentTarget.textContent;
 		setFileName(changedName);
 		handleEditFileName(changedName);
-
-		setToggleEdit(false);
-		nameEditReferenece.current.contentEditable = false;
 	};
 
 	const handleDeleteFileButtonClick = e => {
+		if (isProtectedFile) {
+			noticeThieFileIsProtected();
+			return;
+		}
+
 		const acceptDeleteThisFile = confirm(ACCEPT_DELETE_NOTIFICATION);
 		if (!acceptDeleteThisFile) return;
 
@@ -61,7 +78,10 @@ function File({
 	};
 
 	const handleKeyDown = e => {
-		if (e.keyCode === KEY_CODE_ENTER) handleEditFileNameEnd(e);
+		if (e.keyCode === KEY_CODE_ENTER) {
+			setToggleEdit(false);
+			nameEditReferenece.current.contentEditable = false;
+		}
 	};
 
 	return (

--- a/cocode/src/components/Project/File/index.js
+++ b/cocode/src/components/Project/File/index.js
@@ -16,6 +16,9 @@ import {
 import FileImagesSrc from 'constants/fileImagesSrc';
 import { KEY_CODE_ENTER } from 'constants/keyCode';
 
+// Constants
+const ACCEPT_DELETE_NOTIFICATION = '이 파일을 지우시겠습니까?';
+
 function File({
 	isDirectory,
 	_id,
@@ -25,6 +28,7 @@ function File({
 	handleSelectFile,
 	handleCreateFile,
 	handleEditFileName,
+	handleDeleteFile,
 	...props
 }) {
 	const [fileName, setFileName] = useState(name);
@@ -46,6 +50,14 @@ function File({
 
 		setToggleEdit(false);
 		nameEditReferenece.current.contentEditable = false;
+	};
+
+	const handleDeleteFileButtonClick = e => {
+		const acceptDeleteThisFile = confirm(ACCEPT_DELETE_NOTIFICATION);
+		if (!acceptDeleteThisFile) return;
+
+		e.stopPropagation();
+		handleDeleteFile(_id);
 	};
 
 	const handleKeyDown = e => {
@@ -83,7 +95,7 @@ function File({
 						/>
 					</>
 				)}
-				<DeleteIcon />
+				<DeleteIcon onClick={handleDeleteFileButtonClick} />
 			</Styled.SideIcons>
 		</Styled.File>
 	);

--- a/cocode/src/components/Project/File/index.js
+++ b/cocode/src/components/Project/File/index.js
@@ -78,11 +78,21 @@ function File({
 		}
 	};
 
+	const handleDragStart = e => {
+		e.dataTransfer.setData('text', _id);
+		e.stopPropagation();
+	};
+
+	const handleDragOver = e => e.preventDefault();
+
 	return (
 		<Styled.File
+			draggable={true}
 			toggleEdit={toggleEdit}
 			depth={depth}
 			onClick={handleSelectFile ? handleClick : undefined}
+			onDragStart={handleDragStart}
+			onDragOver={handleDragOver}
 			{...props}
 		>
 			<Styled.Icon src={FileImagesSrc[type]} alt={`${name}_${type}`} />

--- a/cocode/src/components/Project/File/index.js
+++ b/cocode/src/components/Project/File/index.js
@@ -18,6 +18,8 @@ import { KEY_CODE_ENTER } from 'constants/keyCode';
 
 // Constants
 const ACCEPT_DELETE_NOTIFICATION = '이 파일을 지우시겠습니까?';
+const WARNING_PREVENT_NOTIFICATION =
+	'해당 파일은 이름을 변경하거나 삭제할 수 없습니다.';
 
 function File({
 	isDirectory,
@@ -36,21 +38,16 @@ function File({
 	const [toggleEdit, setToggleEdit] = useState(false);
 	const nameEditReferenece = useRef(null);
 
+	// Functions
+	const checkThisFileIsProtected = () =>
+		isProtectedFile && !alert(WARNING_PREVENT_NOTIFICATION);
+
 	// Event handlers
-	const noticeThieFileIsProtected = () => {
-		const WARNING_PREVENT_NOTIFICATION =
-			'해당 파일은 이름을 변경하거나 삭제할 수 없습니다.';
-		alert(WARNING_PREVENT_NOTIFICATION);
-	};
 	const handleClick = () => handleSelectFile(_id);
 
 	const handleEditFileNameStart = e => {
 		e.stopPropagation();
-
-		if (isProtectedFile) {
-			noticeThieFileIsProtected();
-			return;
-		}
+		if (checkThisFileIsProtected()) return;
 
 		changeDivEditable(nameEditReferenece.current, true);
 		setToggleEdit(true);
@@ -65,15 +62,12 @@ function File({
 	};
 
 	const handleDeleteFileButtonClick = e => {
-		if (isProtectedFile) {
-			noticeThieFileIsProtected();
-			return;
-		}
+		e.stopPropagation();
+		if (checkThisFileIsProtected()) return;
 
 		const acceptDeleteThisFile = confirm(ACCEPT_DELETE_NOTIFICATION);
 		if (!acceptDeleteThisFile) return;
 
-		e.stopPropagation();
 		handleDeleteFile(_id);
 	};
 

--- a/cocode/src/components/Project/FileTabBar/index.js
+++ b/cocode/src/components/Project/FileTabBar/index.js
@@ -60,7 +60,9 @@ function FileTabBar() {
 
 	const updateOpenedFile = () => {
 		if (!openFiles.length) return;
-		const newOpenFile = openFiles.map(({ _id }) => files[_id]);
+		const newOpenFile = openFiles
+			.map(({ _id }) => files[_id])
+			.filter(file => file);
 		setOpenFiles(newOpenFile);
 	};
 

--- a/cocode/src/constants/theme.js
+++ b/cocode/src/constants/theme.js
@@ -12,7 +12,7 @@ const DEFAULT_THEME = {
 const DROPDOWN_THEME = {
 	dropdownButtonColor: '#2b2b2b',
 	dropdownButtonHoverColor: '#4b4b4b',
-	dropdownButtonBorderColor: '#383838',
+	dropdownButtonBorderColor: '#383838'
 };
 
 const BROWSER_THEME = {
@@ -73,6 +73,8 @@ const EXPLORER_TAB_CONTAINER_THEME = {
 	explorerTabContainerFileNameEditBGColor: '#000',
 	explorerTabContainerFileEditBGColor: 'rgba(55, 65, 64, 0.314)',
 	explorerTabContainerSelectedFileBGColor: '#2accf944',
+	explorerTabContainerFileDropZoneOverBGColor: '#2accf922',
+	explorerTabContainerFileDropZoneNotOverBGColor: 'none',
 
 	explorerTabContainerIconHoverColor: '#fff',
 	explorerTabContainerIconColor: '#878788',
@@ -105,7 +107,7 @@ const FILE_TAB_THEME = {
 
 const MONACO_THEME = {
 	editorMainColor: '#1E2022',
-	editorCurrentLineColor: '#2a2f32',
+	editorCurrentLineColor: '#2a2f32'
 };
 
 export {

--- a/cocode/src/containers/Project/ExplorerTab/index.js
+++ b/cocode/src/containers/Project/ExplorerTab/index.js
@@ -11,7 +11,8 @@ import NewFile from 'components/Project/NewFile';
 import ProjectContext from 'contexts/ProjectContext';
 import {
 	selectFileActionCreator,
-	updateFileNameActionCreator
+	updateFileNameActionCreator,
+	deleteFileActionCreator
 } from 'actions/Project';
 
 const TAB_TITLE = 'EXPLOLER';
@@ -60,6 +61,11 @@ function ExplorerTab() {
 		dispatchProject(updateFileNameAction);
 	};
 
+	const handleDeleteFile = deleteFileId => {
+		const updateFileNameAction = deleteFileActionCreator({ deleteFileId });
+		dispatchProject(updateFileNameAction);
+	};
+
 	return (
 		<>
 			<TabHeader handleCreateFile={handleCreateFile} />
@@ -78,6 +84,7 @@ function ExplorerTab() {
 					depth={1}
 					handleSelectFile={handleSelectFile}
 					handleEditFileName={handleEditFileName}
+					handleDeleteFile={handleDeleteFile}
 				/>
 			</Styled.TabBody>
 		</>

--- a/cocode/src/containers/Project/ExplorerTab/index.js
+++ b/cocode/src/containers/Project/ExplorerTab/index.js
@@ -7,12 +7,14 @@ import {
 } from 'components/Project/ExplorerTabIcons';
 import Directory from 'components/Project/Directory';
 import NewFile from 'components/Project/NewFile';
+import DropZone from 'components/Common/DropZone';
 
 import ProjectContext from 'contexts/ProjectContext';
 import {
 	selectFileActionCreator,
 	updateFileNameActionCreator,
-	deleteFileActionCreator
+	deleteFileActionCreator,
+	moveFileActionCreator
 } from 'actions/Project';
 
 const TAB_TITLE = 'EXPLOLER';
@@ -66,6 +68,14 @@ function ExplorerTab() {
 		dispatchProject(updateFileNameAction);
 	};
 
+	const handleMoveFile = (directoryId, fileId) => {
+		const moveFileAction = moveFileActionCreator({
+			directoryId,
+			fileId
+		});
+		dispatchProject(moveFileAction);
+	};
+
 	return (
 		<>
 			<TabHeader handleCreateFile={handleCreateFile} />
@@ -85,6 +95,7 @@ function ExplorerTab() {
 					handleSelectFile={handleSelectFile}
 					handleEditFileName={handleEditFileName}
 					handleDeleteFile={handleDeleteFile}
+					handleMoveFile={handleMoveFile}
 				/>
 			</Styled.TabBody>
 		</>

--- a/cocode/src/containers/Project/TabContainer/style.js
+++ b/cocode/src/containers/Project/TabContainer/style.js
@@ -3,11 +3,8 @@ import { TAB_CONTAINER_THEME } from 'constants/theme';
 
 const Container = styled.section`
 	& {
-		min-width: 18rem;
 		background-color: ${TAB_CONTAINER_THEME.tabContainerBGColor};
 	}
 `;
 
-export {
-	Container
-};
+export { Container };

--- a/cocode/src/dummy/Project.js
+++ b/cocode/src/dummy/Project.js
@@ -137,11 +137,7 @@ const project = {
 			_id: '5dd553be4561ae2bae9cb463',
 			name: 'root',
 			type: 'directory',
-			child: [
-				'5dd553be4561ae2bae9cb45f'
-				// '5dd553be4561ae2bae9cb461',
-				// '5dd553be4561ae2bae9cb462'
-			]
+			child: ['5dd553be4561ae2bae9cb45f', '5dd553be4561ae2bae9cb462']
 		},
 		{
 			_id: '5dd553be4561ae2bae9cb45f',
@@ -182,13 +178,13 @@ const project = {
 			type: 'js',
 			contents: getTemplate('Banana'),
 			_id: '5dd553be4561ae2bae9cb460'
+		},
+		{
+			name: 'package.json',
+			type: 'npm',
+			contents: getTemplate('package'),
+			_id: '5dd553be4561ae2bae9cb462'
 		}
-		// {
-		// 	name: 'package.json',
-		// 	type: 'npm',
-		// 	contents: getTemplate('package'),
-		// 	_id: '5dd553be4561ae2bae9cb462'
-		// }
 	]
 };
 

--- a/cocode/src/reducers/ProjectReducer.js
+++ b/cocode/src/reducers/ProjectReducer.js
@@ -172,14 +172,8 @@ function updatePathOfChild(prePath, files, child) {
 }
 
 // Delete file
-const WARNING_NOTIFICATION = '해당 파일은 삭제할 수 없습니다.';
 const deleteFile = (state, { deleteFileId }) => {
-	const { files, entry, root } = state;
-	if (isProtectedFile({ files, root, entry, deleteFileId })) {
-		alert(WARNING_NOTIFICATION);
-		return { ...state };
-	}
-
+	const { files } = state;
 	const { parentId } = files[deleteFileId];
 	const updatedParentChilds = state.files[parentId].child.filter(
 		id => id !== deleteFileId
@@ -197,21 +191,6 @@ const deleteFile = (state, { deleteFileId }) => {
 		}
 	};
 };
-
-// src 디렉토리의 index.js, src 디렉토리, package.json은 삭제불가
-function isProtectedFile({ files, root, entry, deleteFileId }) {
-	if (deleteFileId === entry) return true;
-
-	const entryParentId = files[entry].parentId;
-	if (deleteFileId === entryParentId) return true;
-
-	const deleteFileName = files[deleteFileId].name;
-	const deleteFileParentId = files[deleteFileId].parentId;
-	if (deleteFileName === 'package.json' && deleteFileParentId === root)
-		return true;
-
-	return false;
-}
 
 function ProjectReducer(state, { type, payload }) {
 	const reducers = {

--- a/cocode/src/reducers/ProjectReducer.js
+++ b/cocode/src/reducers/ProjectReducer.js
@@ -129,8 +129,15 @@ const updateFileName = (state, { selectedFileId, changedName }) => {
 	};
 };
 
+const WARNING_NOTIFICATION = '해당 파일은 삭제할 수 없습니다.';
 const deleteFile = (state, { deleteFileId }) => {
-	const { parentId } = state.files[deleteFileId];
+	const { files, entry, root } = state;
+	if (isProtectedFile({ files, root, entry, deleteFileId })) {
+		alert(WARNING_NOTIFICATION);
+		return { ...state };
+	}
+
+	const { parentId } = files[deleteFileId];
 	const updatedParentChilds = state.files[parentId].child.filter(
 		id => id !== deleteFileId
 	);
@@ -147,6 +154,21 @@ const deleteFile = (state, { deleteFileId }) => {
 		}
 	};
 };
+
+// src 디렉토리의 index.js, src 디렉토리, package.json은 삭제불가
+function isProtectedFile({ files, root, entry, deleteFileId }) {
+	if (deleteFileId === entry) return true;
+
+	const entryParentId = files[entry].parentId;
+	if (deleteFileId === entryParentId) return true;
+
+	const deleteFileName = files[deleteFileId].name;
+	const deleteFileParentId = files[deleteFileId].parentId;
+	if (deleteFileName === 'package.json' && deleteFileParentId === root)
+		return true;
+
+	return false;
+}
 
 function ProjectReducer(state, { type, payload }) {
 	const reducers = {

--- a/cocode/src/reducers/ProjectReducer.js
+++ b/cocode/src/reducers/ProjectReducer.js
@@ -5,7 +5,8 @@ import {
 	SELECT_FILE,
 	CREATE_FILE,
 	UPDATE_FILE_NAME,
-	DELETE_FILE
+	DELETE_FILE,
+	MOVE_FILE
 } from 'actions/types';
 
 import { getFileExtension } from 'utils';
@@ -192,6 +193,40 @@ const deleteFile = (state, { deleteFileId }) => {
 	};
 };
 
+// Move file
+const moveFile = (state, { directoryId, fileId }) => {
+	const parentIdOfMovedFile = state.files[fileId].parentId;
+	if (parentIdOfMovedFile === directoryId) return state;
+
+	const changedChild = state.files[parentIdOfMovedFile].child.filter(
+		childId => childId !== fileId
+	);
+	const newChild = state.files[directoryId].child.filter(
+		childId => childId !== fileId
+	);
+	const newPath = `${state.files[directoryId].path}/${state.files[fileId].name}`;
+
+	return {
+		...state,
+		files: {
+			...state.files,
+			[directoryId]: {
+				...state.files[directoryId],
+				child: [...newChild, fileId]
+			},
+			[fileId]: {
+				...state.files[fileId],
+				parentId: directoryId,
+				path: newPath
+			},
+			[parentIdOfMovedFile]: {
+				...state.files[parentIdOfMovedFile],
+				child: [...changedChild]
+			}
+		}
+	};
+};
+
 function ProjectReducer(state, { type, payload }) {
 	const reducers = {
 		[FETCH_PROJECT]: fetchProject,
@@ -199,7 +234,8 @@ function ProjectReducer(state, { type, payload }) {
 		[SELECT_FILE]: selectFile,
 		[UPDATE_FILE_NAME]: updateFileName,
 		[CREATE_FILE]: createFile,
-		[DELETE_FILE]: deleteFile
+		[DELETE_FILE]: deleteFile,
+		[MOVE_FILE]: moveFile
 	};
 
 	const reducer = reducers[type];

--- a/cocode/src/reducers/ProjectReducer.js
+++ b/cocode/src/reducers/ProjectReducer.js
@@ -195,33 +195,33 @@ const deleteFile = (state, { deleteFileId }) => {
 
 // Move file
 const moveFile = (state, { directoryId, fileId }) => {
-	const parentIdOfMovedFile = state.files[fileId].parentId;
-	if (parentIdOfMovedFile === directoryId) return state;
+	const { files } = state;
 
-	const changedChild = state.files[parentIdOfMovedFile].child.filter(
-		childId => childId !== fileId
-	);
-	const newChild = state.files[directoryId].child.filter(
-		childId => childId !== fileId
-	);
-	const newPath = `${state.files[directoryId].path}/${state.files[fileId].name}`;
+	const oldParentId = files[fileId].parentId;
+	if (oldParentId === directoryId) return state;
+
+	const updateChild = list => list.filter(childId => childId !== fileId);
+	const updatedChildAtOldParent = updateChild(files[oldParentId].child);
+	const updatedChildAtNewParent = updateChild(files[directoryId].child);
+
+	const newPath = `${files[directoryId].path}/${files[fileId].name}`;
 
 	return {
 		...state,
 		files: {
-			...state.files,
+			...files,
 			[directoryId]: {
-				...state.files[directoryId],
-				child: [...newChild, fileId]
+				...files[directoryId],
+				child: [...updatedChildAtNewParent, fileId]
 			},
 			[fileId]: {
-				...state.files[fileId],
+				...files[fileId],
 				parentId: directoryId,
 				path: newPath
 			},
-			[parentIdOfMovedFile]: {
-				...state.files[parentIdOfMovedFile],
-				child: [...changedChild]
+			[oldParentId]: {
+				...files[oldParentId],
+				child: [...updatedChildAtOldParent]
 			}
 		}
 	};

--- a/cocode/src/reducers/ProjectReducer.js
+++ b/cocode/src/reducers/ProjectReducer.js
@@ -4,7 +4,8 @@ import {
 	FETCH_PROJECT,
 	SELECT_FILE,
 	CREATE_FILE,
-	UPDATE_FILE_NAME
+	UPDATE_FILE_NAME,
+	DELETE_FILE
 } from 'actions/types';
 
 import { getFileExtension } from 'utils';
@@ -128,13 +129,33 @@ const updateFileName = (state, { selectedFileId, changedName }) => {
 	};
 };
 
+const deleteFile = (state, { deleteFileId }) => {
+	const { parentId } = state.files[deleteFileId];
+	const updatedParentChilds = state.files[parentId].child.filter(
+		id => id !== deleteFileId
+	);
+
+	return {
+		...state,
+		files: {
+			...state.files,
+			[deleteFileId]: undefined,
+			[parentId]: {
+				...state.files[parentId],
+				child: updatedParentChilds
+			}
+		}
+	};
+};
+
 function ProjectReducer(state, { type, payload }) {
 	const reducers = {
 		[FETCH_PROJECT]: fetchProject,
 		[UPDATE_CODE]: updateCode,
 		[SELECT_FILE]: selectFile,
 		[UPDATE_FILE_NAME]: updateFileName,
-		[CREATE_FILE]: createFile
+		[CREATE_FILE]: createFile,
+		[DELETE_FILE]: deleteFile
 	};
 
 	const reducer = reducers[type];

--- a/cocode/src/reducers/ProjectReducer.js
+++ b/cocode/src/reducers/ProjectReducer.js
@@ -165,7 +165,7 @@ function updatePathOfChild(prePath, files, child) {
 				...result,
 				...changedChildFiles,
 				[_id]: {
-					...file,
+					...files[_id],
 					path
 				}
 			};


### PR DESCRIPTION
## 간단한 요약 설명
- 탐색기 탭에서 drag & drop api를 이용하여 파일을 이동시키는 기능을 구현했습니다.
- 디렉토리 타입의 파일을 클릭하면 해당하는 디렉토리의 파일목록을 보이게, 숨기게 할 수 있습니다.

## 관련 이슈
* close #195 
