### PR TITLE
대시보드 페이지 이름 변경 및 삭제 상태관리 및 서버연동

### DIFF
--- a/cocode/src/actions/API.js
+++ b/cocode/src/actions/API.js
@@ -1,20 +1,23 @@
-import { API_LOADING, API_SUCCESS, API_FAIL } from './types';
+import { API_READY, API_LOADING, API_SUCCESS, API_FAIL } from './types';
 
 function fetchLoadActionCreator() {
-	return {
-		type: API_LOADING
-	};
+	return { type: API_LOADING };
 }
 
-function fetchSuccessActionCreator({ data }) {
-	return { type: API_SUCCESS, payload: data };
+function fetchSuccessActionCreator({ status, data }) {
+	return { type: API_SUCCESS, payload: { status, data } };
 }
 
 function fetchFailActionCreator(error) {
 	return { type: API_FAIL, payload: error };
 }
 
+function fetchReadyActionCreator() {
+	return { type: API_READY };
+}
+
 export {
+	fetchReadyActionCreator,
 	fetchLoadActionCreator,
 	fetchSuccessActionCreator,
 	fetchFailActionCreator

--- a/cocode/src/actions/Dashboard.js
+++ b/cocode/src/actions/Dashboard.js
@@ -1,0 +1,19 @@
+import { UPDATE_COCONUT_NAME, DELETE_COCONUT, FETCH_COCONUT } from './types';
+
+function fetchCoconutActionCreator(payload) {
+	return { type: FETCH_COCONUT, payload };
+}
+
+function updateCoconutNameActionCreator(payload) {
+	return { type: UPDATE_COCONUT_NAME, payload };
+}
+
+function deleteCoconutActionCreator(payload) {
+	return { type: DELETE_COCONUT, payload };
+}
+
+export {
+	fetchCoconutActionCreator,
+	updateCoconutNameActionCreator,
+	deleteCoconutActionCreator
+};

--- a/cocode/src/actions/types.js
+++ b/cocode/src/actions/types.js
@@ -10,6 +10,10 @@ const SELECT_FILE = 'selectFile';
 const CREATE_FILE = 'createFile';
 const UPDATE_FILE_NAME = 'updateFileName';
 
+//DashBoard
+const UPDATE_COCONUT_NAME = 'updateCoconutName';
+const DELETE_COCONUT = 'deleteCoconut';
+
 export {
 	API_LOADING,
 	API_SUCCESS,
@@ -18,5 +22,7 @@ export {
 	FETCH_PROJECT,
 	SELECT_FILE,
 	UPDATE_FILE_NAME,
-	CREATE_FILE
+	CREATE_FILE,
+	UPDATE_COCONUT_NAME,
+	DELETE_COCONUT,
 };

--- a/cocode/src/actions/types.js
+++ b/cocode/src/actions/types.js
@@ -1,4 +1,5 @@
 // API
+const API_READY = 'API_READY';
 const API_LOADING = 'API_LOADING';
 const API_SUCCESS = 'API_SUCCESS';
 const API_FAIL = 'API_FAILURE';
@@ -16,6 +17,7 @@ const UPDATE_COCONUT_NAME = 'updateCoconutName';
 const DELETE_COCONUT = 'deleteCoconut';
 
 export {
+	API_READY,
 	API_LOADING,
 	API_SUCCESS,
 	API_FAIL,

--- a/cocode/src/actions/types.js
+++ b/cocode/src/actions/types.js
@@ -11,6 +11,7 @@ const CREATE_FILE = 'createFile';
 const UPDATE_FILE_NAME = 'updateFileName';
 
 //DashBoard
+const FETCH_COCONUT = 'fetchCoconut';
 const UPDATE_COCONUT_NAME = 'updateCoconutName';
 const DELETE_COCONUT = 'deleteCoconut';
 
@@ -23,6 +24,7 @@ export {
 	SELECT_FILE,
 	UPDATE_FILE_NAME,
 	CREATE_FILE,
+	FETCH_COCONUT,
 	UPDATE_COCONUT_NAME,
 	DELETE_COCONUT,
 };

--- a/cocode/src/apis/DashBoard.js
+++ b/cocode/src/apis/DashBoard.js
@@ -7,4 +7,12 @@ function getCoconutsAPICreator(username) {
 	};
 }
 
-export { getCoconutsAPICreator };
+function updateCoconutsAPICreator(projectId, data) {
+	return {
+		url: `${API.projects}/${projectId}`,
+		method: 'patch',
+		data
+	};
+}
+
+export { getCoconutsAPICreator, updateCoconutsAPICreator };

--- a/cocode/src/apis/DashBoard.js
+++ b/cocode/src/apis/DashBoard.js
@@ -15,4 +15,15 @@ function updateCoconutsAPICreator(projectId, data) {
 	};
 }
 
-export { getCoconutsAPICreator, updateCoconutsAPICreator };
+function deleteCoconutsAPICreator(projectId) {
+	return {
+		url: `${API.projects}/${projectId}`,
+		method: 'delete'
+	};
+}
+
+export {
+	getCoconutsAPICreator,
+	updateCoconutsAPICreator,
+	deleteCoconutsAPICreator
+};

--- a/cocode/src/components/Common/DropDownMenu/index.js
+++ b/cocode/src/components/Common/DropDownMenu/index.js
@@ -6,14 +6,22 @@ function DropDownMenu({ children, menuItems, ...props }) {
 	const [isOpen, setIsOpen] = useState(false);
 
 	const handleIsOpen = () => setIsOpen(!isOpen);
+	const handleMenuClose = () => setIsOpen(false);
 	return (
 		<Styled.DropDownMenu {...props}>
 			{React.cloneElement(children, { onClick: handleIsOpen })}
 			{isOpen && (
 				<Styled.DropDownList>
 					{menuItems &&
-						menuItems.map(({ value, ...props }, key) => (
-							<Styled.DropDownItem {...props} key={key}>
+						menuItems.map(({ value, onClick, ...props }, key) => (
+							<Styled.DropDownItem
+								onClick={e => {
+									handleMenuClose();
+									onClick(e);
+								}}
+								{...props}
+								key={key}
+							>
 								{value}
 							</Styled.DropDownItem>
 						))}

--- a/cocode/src/components/Common/DropDownMenu/index.js
+++ b/cocode/src/components/Common/DropDownMenu/index.js
@@ -6,25 +6,30 @@ function DropDownMenu({ children, menuItems, ...props }) {
 	const [isOpen, setIsOpen] = useState(false);
 
 	const handleIsOpen = () => setIsOpen(!isOpen);
-	const handleMenuClose = () => setIsOpen(false);
+	const handleMenuClose = (handleClick, e) => {
+		setIsOpen(false);
+		handleClick(e);
+	};
 	return (
 		<Styled.DropDownMenu {...props}>
 			{React.cloneElement(children, { onClick: handleIsOpen })}
 			{isOpen && (
 				<Styled.DropDownList>
 					{menuItems &&
-						menuItems.map(({ value, onClick, ...props }, key) => (
-							<Styled.DropDownItem
-								onClick={e => {
-									handleMenuClose();
-									onClick(e);
-								}}
-								{...props}
-								key={key}
-							>
-								{value}
-							</Styled.DropDownItem>
-						))}
+						menuItems.map(
+							({ value, handleClick, ...props }, key) => (
+								<Styled.DropDownItem
+									onClick={handleMenuClose.bind(
+										undefined,
+										handleClick
+									)}
+									{...props}
+									key={key}
+								>
+									{value}
+								</Styled.DropDownItem>
+							)
+						)}
 				</Styled.DropDownList>
 			)}
 		</Styled.DropDownMenu>

--- a/cocode/src/components/DashBoard/ProjectCard/index.js
+++ b/cocode/src/components/DashBoard/ProjectCard/index.js
@@ -1,7 +1,12 @@
-import React from 'react';
+import React, { useState, useRef } from 'react';
 import * as Styled from './style';
 import DropDownMenu from 'components/Common/DropDownMenu';
 import moment from 'moment';
+import { KEY_CODE_ENTER } from 'constants/keyCode';
+import {
+	selectAllTextAboutFocusedDom,
+	changeDivEditable
+} from 'utils/domControl';
 
 //TODO onClick시 api 요청 이벤트 핸들러 추가
 const defaultMenuItems = [
@@ -30,14 +35,47 @@ function MenuButton({ onClick }) {
 }
 
 function ProjectCard({ name, updatedAt, menuItems = defaultMenuItems }) {
+	const renameMenu = [
+		{
+			value: 'rename',
+			onClick: () => handleEditCoconutNameStart()
+		}
+	];
+
+	const [_, setCoconutName] = useState(name);
+	const nameInput = useRef(null);
+
+	const handleEditCoconutNameStart = () => {
+		changeDivEditable(nameInput.current, true);
+	};
+	const handleEditCoconutNameEnd = () => {
+		const changedName = nameInput.current.value;
+		setCoconutName(changedName);
+		console.log('end');
+
+		nameInput.current.contentEditable = false;
+	};
+
+	const handleKeyDown = ({ keyCode }) => {
+		if (keyCode === KEY_CODE_ENTER) {
+			handleEditCoconutNameEnd();
+		}
+	};
+
 	return (
 		<Styled.ProjectArticle>
-			<Styled.ProjectTitle>{name}</Styled.ProjectTitle>
+			<Styled.ProjectTitle
+				ref={nameInput}
+				onFocus={selectAllTextAboutFocusedDom}
+				onKeyDown={handleKeyDown}
+			>
+				{name}
+			</Styled.ProjectTitle>
 			<Styled.ProjectDescription>
 				<Styled.ProjectTimeLabel>
 					Edited {moment(updatedAt).fromNow()}
 				</Styled.ProjectTimeLabel>
-				<DropDownMenu menuItems={menuItems}>
+				<DropDownMenu menuItems={renameMenu}>
 					<MenuButton />
 				</DropDownMenu>
 			</Styled.ProjectDescription>

--- a/cocode/src/components/DashBoard/ProjectCard/index.js
+++ b/cocode/src/components/DashBoard/ProjectCard/index.js
@@ -34,19 +34,19 @@ function ProjectCard({ _id, name, updatedAt }) {
 	const renameMenu = [
 		{
 			value: 'open',
-			onClick: () => alert('open')
+			handleClick: () => alert('open')
 		},
 		{
 			value: 'rename',
-			onClick: () => handleEditCoconutNameStart()
+			handleClick: () => handleEditCoconutNameStart()
 		},
 		{
 			value: 'remove',
-			onClick: () => handleRemoveCoconut()
+			handleClick: () => handleRemoveCoconut()
 		}
 	];
 
-	const { dispatch } = useContext(DashBoardContext);
+	const { dispatchDashboard } = useContext(DashBoardContext);
 	const [modifying, setModifying] = useState(false);
 	const [deleting, setDeleting] = useState(false);
 	const nameInput = useRef(false);
@@ -60,10 +60,7 @@ function ProjectCard({ _id, name, updatedAt }) {
 	};
 	const handleEditCoconutNameEnd = () => {
 		nameInput.current.contentEditable = false;
-		fetchName(nameInput.current.textContent);
-	};
-
-	const fetchName = name => {
+		const name = nameInput.current.textContent;
 		setRequest(updateCoconutsAPICreator(_id, { name }));
 	};
 
@@ -84,12 +81,12 @@ function ProjectCard({ _id, name, updatedAt }) {
 
 		if (modifying && data) {
 			setModifying(false);
-			dispatch(updateCoconutNameActionCreator(data));
+			dispatchDashboard(updateCoconutNameActionCreator(data));
 		}
 
 		if (deleting) {
 			setDeleting(false);
-			dispatch(deleteCoconutActionCreator(_id));
+			dispatchDashboard(deleteCoconutActionCreator(_id));
 		}
 	}, [loading, status]);
 

--- a/cocode/src/components/DashBoard/ProjectCard/index.js
+++ b/cocode/src/components/DashBoard/ProjectCard/index.js
@@ -2,7 +2,10 @@ import React, { useEffect, useRef, useContext, useState } from 'react';
 import * as Styled from './style';
 import moment from 'moment';
 import DropDownMenu from 'components/Common/DropDownMenu';
-import { updateCoconutNameActionCreator } from 'actions/Dashboard';
+import {
+	updateCoconutNameActionCreator,
+	deleteCoconutActionCreator
+} from 'actions/Dashboard';
 import DashBoardContext from 'contexts/DashBoardContext';
 import useFetch from 'hooks/useFetch';
 import { KEY_CODE_ENTER } from 'constants/keyCode';
@@ -43,10 +46,11 @@ function ProjectCard({ _id, name, updatedAt }) {
 
 	const { dispatch } = useContext(DashBoardContext);
 	const [modifying, setModifying] = useState(false);
+	const [deleting, setDeleting] = useState(false);
 	const nameInput = useRef(false);
 
 	//TODO loading 시 Circular, error시 토스트 띄우기
-	const [{ data, loading, error }, setRequest] = useFetch({});
+	const [{ data, loading, error, status }, setRequest] = useFetch({});
 
 	const handleEditCoconutNameStart = () => {
 		setModifying(true);
@@ -61,18 +65,28 @@ function ProjectCard({ _id, name, updatedAt }) {
 		setRequest(updateCoconutsAPICreator(_id, { name }));
 	};
 
+	const handleRemoveCoconut = () => {
+		setDeleting(true);
+		setRequest(deleteCoconutsAPICreator(_id));
+	};
+
 	const handleKeyDown = e => {
 		if (e.keyCode === KEY_CODE_ENTER) handleEditCoconutNameEnd();
 	};
 
 	useEffect(() => {
-		if (!data) return;
+		if (loading) return;
 
-		if (modifying) {
-			dispatch(updateCoconutNameActionCreator(data));
+		if (modifying && data) {
 			setModifying(false);
+			dispatch(updateCoconutNameActionCreator(data));
 		}
-	}, [data]);
+
+		if (deleting) {
+			setDeleting(false);
+			dispatch(deleteCoconutActionCreator(_id));
+		}
+		}, [loading, status]);
 
 	return (
 		<Styled.ProjectArticle>

--- a/cocode/src/components/DashBoard/ProjectCard/index.js
+++ b/cocode/src/components/DashBoard/ProjectCard/index.js
@@ -18,6 +18,8 @@ import {
 	deleteCoconutsAPICreator
 } from 'apis/DashBoard';
 
+const ACCEPT_DELETE_NOTIFICATION = '이 프로젝트 지우시겠습니까?';
+
 function MenuButton({ onClick }) {
 	return (
 		<Styled.ProjectMenuButton onClick={onClick}>
@@ -66,6 +68,9 @@ function ProjectCard({ _id, name, updatedAt }) {
 	};
 
 	const handleRemoveCoconut = () => {
+		const acceptDeleteThisCoconut = confirm(ACCEPT_DELETE_NOTIFICATION);
+		if (!acceptDeleteThisCoconut) return;
+
 		setDeleting(true);
 		setRequest(deleteCoconutsAPICreator(_id));
 	};
@@ -86,7 +91,7 @@ function ProjectCard({ _id, name, updatedAt }) {
 			setDeleting(false);
 			dispatch(deleteCoconutActionCreator(_id));
 		}
-		}, [loading, status]);
+	}, [loading, status]);
 
 	return (
 		<Styled.ProjectArticle>

--- a/cocode/src/components/DashBoard/ProjectCard/index.js
+++ b/cocode/src/components/DashBoard/ProjectCard/index.js
@@ -42,14 +42,14 @@ function ProjectCard({ _id, name, updatedAt }) {
 	];
 
 	const { dispatch } = useContext(DashBoardContext);
-	const [modify, setModify] = useState(false);
+	const [modifying, setModifying] = useState(false);
 	const nameInput = useRef(false);
 
 	//TODO loading 시 Circular, error시 토스트 띄우기
 	const [{ data, loading, error }, setRequest] = useFetch({});
 
 	const handleEditCoconutNameStart = () => {
-		setModify(true);
+		setModifying(true);
 		changeDivEditable(nameInput.current, true);
 	};
 	const handleEditCoconutNameEnd = e => {
@@ -61,16 +61,16 @@ function ProjectCard({ _id, name, updatedAt }) {
 		setRequest(updateCoconutsAPICreator(_id, { name }));
 	};
 
-	const handleKeyDown = ({ currentTarget, keyCode }) => {
-		if (keyCode === KEY_CODE_ENTER) {
-			handleEditCoconutNameEnd(currentTarget.textContent);
-		}
+	const handleKeyDown = e => {
+		if (e.keyCode === KEY_CODE_ENTER) handleEditCoconutNameEnd(e);
 	};
 
 	useEffect(() => {
-		if (modify && data) {
+		if (!data) return;
+
+		if (modifying) {
 			dispatch(updateCoconutNameActionCreator(data));
-			setModify(false);
+			setModifying(false);
 		}
 	}, [data]);
 

--- a/cocode/src/components/DashBoard/ProjectCard/index.js
+++ b/cocode/src/components/DashBoard/ProjectCard/index.js
@@ -52,9 +52,9 @@ function ProjectCard({ _id, name, updatedAt }) {
 		setModifying(true);
 		changeDivEditable(nameInput.current, true);
 	};
-	const handleEditCoconutNameEnd = e => {
+	const handleEditCoconutNameEnd = () => {
 		nameInput.current.contentEditable = false;
-		fetchName(e.currentTarget.textContent);
+		fetchName(nameInput.current.textContent);
 	};
 
 	const fetchName = name => {
@@ -62,7 +62,7 @@ function ProjectCard({ _id, name, updatedAt }) {
 	};
 
 	const handleKeyDown = e => {
-		if (e.keyCode === KEY_CODE_ENTER) handleEditCoconutNameEnd(e);
+		if (e.keyCode === KEY_CODE_ENTER) handleEditCoconutNameEnd();
 	};
 
 	useEffect(() => {

--- a/cocode/src/components/DashBoard/ProjectCard/style.js
+++ b/cocode/src/components/DashBoard/ProjectCard/style.js
@@ -26,6 +26,10 @@ const ProjectTitle = styled.h2`
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
+
+	&[contenteditable='true'] br {
+		display: none;
+	}
 `;
 
 const ProjectDescription = styled.div`

--- a/cocode/src/hooks/useFetch.js
+++ b/cocode/src/hooks/useFetch.js
@@ -8,7 +8,6 @@ import {
 	fetchFailActionCreator
 } from 'actions/API';
 
-
 const API = axios.create(DEFAULT_REQUEST_OPTION);
 
 function useFetch({ method, url, data = {} }) {
@@ -22,8 +21,8 @@ function useFetch({ method, url, data = {} }) {
 	const requestToServer = () => {
 		dispatchFetchState(fetchLoadActionCreator);
 		API(request)
-		.then(res => dispatchFetchState(fetchSuccessActionCreator(res)))
-		.catch(error => dispatchFetchState(fetchFailActionCreator(error)));
+			.then(res => dispatchFetchState(fetchSuccessActionCreator(res)))
+			.catch(error => dispatchFetchState(fetchFailActionCreator(error)));
 	};
 
 	useEffect(() => {

--- a/cocode/src/hooks/useFetch.js
+++ b/cocode/src/hooks/useFetch.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { DEFAULT_REQUEST_OPTION } from 'config';
 import APIReducer from 'reducers/APIReducer';
 import {
+	fetchReadyActionCreator,
 	fetchLoadActionCreator,
 	fetchSuccessActionCreator,
 	fetchFailActionCreator
@@ -15,7 +16,8 @@ function useFetch({ method, url, data = {} }) {
 	const [state, dispatchFetchState] = useReducer(APIReducer, {
 		data: false,
 		loading: false,
-		err: false
+		err: false,
+		status: false
 	});
 
 	const requestToServer = () => {
@@ -26,7 +28,10 @@ function useFetch({ method, url, data = {} }) {
 	};
 
 	useEffect(() => {
-		if (request.url) requestToServer();
+		if (!request.url) return;
+
+		requestToServer();
+		return () => dispatchFetchState(fetchReadyActionCreator());
 	}, [request]);
 
 	return [state, setRequest];

--- a/cocode/src/pages/DashBoard/index.js
+++ b/cocode/src/pages/DashBoard/index.js
@@ -9,26 +9,21 @@ import { fetchCoconutActionCreator } from 'actions/Dashboard';
 
 function DashBoard() {
 	const { user } = useContext(UserContext);
-	const [{ coconuts, isFetched }, dispatch] = useReducer(DashBoardReducer, {
-		coconuts: [],
-		isFetched: false
-	});
+	const [coconuts, dispatchDashboard] = useReducer(DashBoardReducer, []);
 	const [{ data, loading, error }, setRequest] = useFetch({});
 
 	useEffect(() => {
 		if (user) setRequest(getCoconutsAPICreator(user.username));
-	}, [user]);
+		if (data) dispatchDashboard(fetchCoconutActionCreator(data));
+	}, [user, data]);
 
-	useEffect(() => {
-		if (!isFetched && data) dispatch(fetchCoconutActionCreator(data));
-	}, [data]);
 
 	//TODO loading 컴포넌트 만들기
 	if (loading) return <p>Loading...</p>;
 	if (error) return <p>다시 시도해주세요.</p>;
 
 	return (
-		<DashBoardContext.Provider value={{ coconuts, dispatch }}>
+		<DashBoardContext.Provider value={{ coconuts, dispatchDashboard }}>
 			<Header />
 			<ProjectCardList />
 		</DashBoardContext.Provider>

--- a/cocode/src/pages/DashBoard/index.js
+++ b/cocode/src/pages/DashBoard/index.js
@@ -28,7 +28,7 @@ function DashBoard() {
 	if (error) return <p>다시 시도해주세요.</p>;
 
 	return (
-		<DashBoardContext.Provider value={{ coconuts }}>
+		<DashBoardContext.Provider value={{ coconuts, dispatch }}>
 			<Header />
 			<ProjectCardList />
 		</DashBoardContext.Provider>

--- a/cocode/src/pages/DashBoard/index.js
+++ b/cocode/src/pages/DashBoard/index.js
@@ -1,14 +1,18 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useReducer } from 'react';
 import ProjectCardList from 'containers/DashBoard/ProjectCardList';
 import Header from 'containers/Common/Header';
+import { UserContext, DashBoardContext } from 'contexts';
+import DashBoardReducer from 'reducers/DashboardReducer';
 import useFetch from 'hooks/useFetch';
 import { getCoconutsAPICreator } from 'apis/DashBoard';
-import { DashBoardContext, UserContext } from 'contexts';
+import { fetchCoconutActionCreator } from 'actions/Dashboard';
 
 function DashBoard() {
 	const { user } = useContext(UserContext);
-	const [coconuts, setCoconuts] = useState([]);
-	const [isFetched, setIsFetched] = useState(false);
+	const [{ coconuts, isFetched }, dispatch] = useReducer(DashBoardReducer, {
+		coconuts: [],
+		isFetched: false
+	});
 	const [{ data, loading, error }, setRequest] = useFetch({});
 
 	useEffect(() => {
@@ -16,10 +20,7 @@ function DashBoard() {
 	}, [user]);
 
 	useEffect(() => {
-		if (!isFetched && data) {
-			setCoconuts(data);
-			setIsFetched(true);
-		}
+		if (!isFetched && data) dispatch(fetchCoconutActionCreator(data));
 	}, [data]);
 
 	//TODO loading 컴포넌트 만들기

--- a/cocode/src/reducers/APIReducer.js
+++ b/cocode/src/reducers/APIReducer.js
@@ -1,14 +1,23 @@
-import { API_LOADING, API_SUCCESS, API_FAIL } from 'actions/types';
+import { API_READY, API_LOADING, API_SUCCESS, API_FAIL } from 'actions/types';
+
+const ready = () => ({
+	data: false,
+	loading: false,
+	err: false,
+	status: false
+});
 
 const loading = () => ({
 	data: undefined,
 	loading: true,
-	error: false
+	error: false,
+	status: false
 });
 
-const success = (state, payload) => ({
+const success = (state, { data, status }) => ({
 	...state,
-	data: payload,
+	data,
+	status,
 	loading: false
 });
 
@@ -20,6 +29,7 @@ const fail = state => ({
 
 function APIReducer(state, { type, payload }) {
 	const reducers = {
+		[API_READY]: ready,
 		[API_LOADING]: loading,
 		[API_SUCCESS]: success,
 		[API_FAIL]: fail

--- a/cocode/src/reducers/DashboardReducer.js
+++ b/cocode/src/reducers/DashboardReducer.js
@@ -4,22 +4,15 @@ import {
 	DELETE_COCONUT
 } from 'actions/types';
 
-const fetchCoconut = (_, coconuts) => ({
-	coconuts,
-	isFetched: true
-});
+const fetchCoconut = (_, coconuts) => coconuts;
 
-const updateCoconutName = ({ coconuts }, newCoconut) => ({
-	coconuts: coconuts.map(coconut =>
+const updateCoconutName = (coconuts, newCoconut) =>
+	coconuts.map(coconut =>
 		coconut._id !== newCoconut._id ? coconut : newCoconut
-	),
-	isFetched: true
-});
+	);
 
-const deleteCoconut = ({ coconuts }, _id) => ({
-	coconuts: coconuts.filter(coconut => coconut._id !== _id),
-	isFetched: true
-});
+const deleteCoconut = (coconuts, _id) =>
+	coconuts.filter(coconut => coconut._id !== _id);
 
 function DashBoardReducer(state, { type, payload }) {
 	const reducers = {

--- a/cocode/src/reducers/DashboardReducer.js
+++ b/cocode/src/reducers/DashboardReducer.js
@@ -16,7 +16,7 @@ const updateCoconutName = ({ coconuts }, newCoconut) => ({
 	isFetched: true
 });
 
-const deleteCoconut = ({ coconuts }, { _id }) => ({
+const deleteCoconut = ({ coconuts }, _id) => ({
 	coconuts: coconuts.filter(coconut => coconut._id !== _id),
 	isFetched: true
 });

--- a/cocode/src/reducers/DashboardReducer.js
+++ b/cocode/src/reducers/DashboardReducer.js
@@ -1,0 +1,35 @@
+import {
+	FETCH_COCONUT,
+	UPDATE_COCONUT_NAME,
+	DELETE_COCONUT
+} from 'actions/types';
+
+const filterNotChangedById = (list, id) => list.filter(item => item._id !== id);
+
+const fetchCoconut = (_, coconuts) => ({
+	coconuts,
+	isFetched: true
+});
+
+const updateCoconutName = (coconuts, newCoconut) => ({
+	coconut: [...filterNotChangedById(coconuts, newCoconut._id), newCoconut],
+	isFetched: true
+});
+
+const deleteCoconut = (coconuts, { _id }) => ({
+	coconut: filterNotChangedById(coconuts, _id),
+	isFetched: true
+});
+
+function DashBoardReducer(state, { type, payload }) {
+	const reducers = {
+		[FETCH_COCONUT]: fetchCoconut,
+		[UPDATE_COCONUT_NAME]: updateCoconutName,
+		[DELETE_COCONUT]: deleteCoconut
+	};
+
+	const reducer = reducers[type];
+	return reducer ? reducer(state, payload) : state;
+}
+
+export default DashBoardReducer;

--- a/cocode/src/reducers/DashboardReducer.js
+++ b/cocode/src/reducers/DashboardReducer.js
@@ -4,20 +4,20 @@ import {
 	DELETE_COCONUT
 } from 'actions/types';
 
-const filterNotChangedById = (list, id) => list.filter(item => item._id !== id);
-
 const fetchCoconut = (_, coconuts) => ({
 	coconuts,
 	isFetched: true
 });
 
-const updateCoconutName = (coconuts, newCoconut) => ({
-	coconut: [...filterNotChangedById(coconuts, newCoconut._id), newCoconut],
+const updateCoconutName = ({ coconuts }, newCoconut) => ({
+	coconuts: coconuts.map(coconut =>
+		coconut._id !== newCoconut._id ? coconut : newCoconut
+	),
 	isFetched: true
 });
 
-const deleteCoconut = (coconuts, { _id }) => ({
-	coconut: filterNotChangedById(coconuts, _id),
+const deleteCoconut = ({ coconuts }, { _id }) => ({
+	coconuts: coconuts.filter(coconut => coconut._id !== _id),
 	isFetched: true
 });
 


### PR DESCRIPTION
## 간단한 요약 설명
이름 변경과 삭제를 각각 PR을 날리려 했으나 변경이 되면 삭제가 이상하고 삭제가 되면 변경이 이상해지는
그런 이슈가 있어서 한번에 날립니다 😱

대시보드의 페이지의 이름 변경 및 삭제시 상태관리를 구현했습니다.
서버와의 연동이 됩니다. 


### 상태코드만으로 응답하는 api 서버, 바디는 빈 객체
삭제 요청을 할 때, api 서버에서 [상태코드만으로 응답](https://github.com/connect-foundation/2019-04/wiki/projects-API)합니다. 
그래서 useEffect 안의 data나 loading 등의 상태만으로 삭제시 코코넛 리스트를 연동할 수 없었고,
useFetch에 res status를 추가해주어 해결했습니다.

### 연속적으로 삭제할 때 동작을 안함
서버에서 응답은 잘 오지만, 상태관리에 반영이 잘 안되는 이슈가 있었고,
useFetch에 한 요청이 끝날 때마다, Fetch에서 관리하는 상태`{data,loading,error,status}`들을 변경해서 해결했습니다.

##  해결 안된 이슈
- 버튼을 눌렀을 때, 드롭다운이 닫히나, 여전히 여러 드롭다운을 띄울 수 있습니다
   - 드롭다운에 onBlur 이벤트를 주면, 드롭다운 아이템의 온클릭 이벤트가 먹지 않습니다 ㅜㅜ

## 대시보드에서 추가적으로 해야할 것 - 스크럼 때 이슈 추가 할게여,,

#### [FE] 
- 프로젝트 생성 API 요청 
- 로그인하지 않은 사용자가 대시보드에 접근할 경우 Home으로 리다이렉트 된다

#### [BE] 
- #67 프로젝트 생성 API 구현
- fix : API 서버에서 프로젝트 삭제 요청을 받을 시 해당 파일들을 삭제
- 수정/삭제시 유저 권한 확인

## 관련 이슈
 close #21 
 close #22 
