### PR TITLE
프로젝트 에디터 이동 기능 구현 

### DIFF
--- a/cocode/src/App.js
+++ b/cocode/src/App.js
@@ -27,7 +27,7 @@ function App() {
 					<Switch>
 						<Route exact path="/" component={Home} />
 						<Route path="/dashboard" component={DashBoard} />
-						<Route path="/project" component={Project} />
+						<Route path="/project/:projectId" component={Project} />
 						<Route path="/history" component={History} />
 					</Switch>
 				</ThemeProvider>

--- a/cocode/src/components/Common/DropDownMenu/index.js
+++ b/cocode/src/components/Common/DropDownMenu/index.js
@@ -5,8 +5,12 @@ import * as Styled from './style';
 function DropDownMenu({ children, menuItems, ...props }) {
 	const [isOpen, setIsOpen] = useState(false);
 
-	const handleIsOpen = () => setIsOpen(!isOpen);
+	const handleIsOpen = (e) => {
+		e.stopPropagation();
+		setIsOpen(!isOpen);
+	};
 	const handleMenuClose = (handleClick, e) => {
+		e.stopPropagation();
 		setIsOpen(false);
 		handleClick(e);
 	};

--- a/cocode/src/components/DashBoard/ProjectCard/index.js
+++ b/cocode/src/components/DashBoard/ProjectCard/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useContext, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import * as Styled from './style';
 import moment from 'moment';
 import DropDownMenu from 'components/Common/DropDownMenu';
@@ -31,21 +32,7 @@ function MenuButton({ onClick }) {
 }
 
 function ProjectCard({ _id, name, updatedAt }) {
-	const renameMenu = [
-		{
-			value: 'open',
-			handleClick: () => alert('open')
-		},
-		{
-			value: 'rename',
-			handleClick: () => handleEditCoconutNameStart()
-		},
-		{
-			value: 'remove',
-			handleClick: () => handleRemoveCoconut()
-		}
-	];
-
+	let history = useHistory();
 	const { dispatchDashboard } = useContext(DashBoardContext);
 	const [modifying, setModifying] = useState(false);
 	const [deleting, setDeleting] = useState(false);
@@ -54,10 +41,13 @@ function ProjectCard({ _id, name, updatedAt }) {
 	//TODO loading 시 Circular, error시 토스트 띄우기
 	const [{ data, loading, error, status }, setRequest] = useFetch({});
 
+	const handleClickOpen = () => history.push(`../project/${_id}`);
+
 	const handleEditCoconutNameStart = () => {
 		setModifying(true);
 		changeDivEditable(nameInput.current, true);
 	};
+
 	const handleEditCoconutNameEnd = () => {
 		nameInput.current.contentEditable = false;
 		const name = nameInput.current.textContent;
@@ -91,7 +81,7 @@ function ProjectCard({ _id, name, updatedAt }) {
 	}, [loading, status]);
 
 	return (
-		<Styled.ProjectArticle>
+		<Styled.ProjectArticle onClick={handleClickOpen}>
 			<Styled.ProjectTitle
 				ref={nameInput}
 				onFocus={selectAllTextAboutFocusedDom}

--- a/cocode/src/components/DashBoard/ProjectCard/index.js
+++ b/cocode/src/components/DashBoard/ProjectCard/index.js
@@ -32,7 +32,7 @@ function MenuButton({ onClick }) {
 }
 
 function ProjectCard({ _id, name, updatedAt }) {
-	let history = useHistory();
+	const history = useHistory();
 	const { dispatchDashboard } = useContext(DashBoardContext);
 	const [modifying, setModifying] = useState(false);
 	const [deleting, setDeleting] = useState(false);

--- a/cocode/src/components/DashBoard/ProjectCard/index.js
+++ b/cocode/src/components/DashBoard/ProjectCard/index.js
@@ -80,6 +80,21 @@ function ProjectCard({ _id, name, updatedAt }) {
 		}
 	}, [loading, status]);
 
+	const renameMenu = [
+		{
+			value: 'open',
+			handleClick: handleClickOpen
+		},
+		{
+			value: 'rename',
+			handleClick: handleEditCoconutNameStart
+		},
+		{
+			value: 'remove',
+			handleClick: handleRemoveCoconut
+		}
+	];
+
 	return (
 		<Styled.ProjectArticle onClick={handleClickOpen}>
 			<Styled.ProjectTitle

--- a/cocode/src/containers/Common/Header/index.js
+++ b/cocode/src/containers/Common/Header/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from 'react';
 import * as Styled from './style';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 
 import deleteCookie from 'utils/deleteCookie';
 
@@ -13,12 +13,13 @@ import LoginModalBody from 'components/Common/LoginModalBody';
 import UserContext from 'contexts/UserContext';
 
 function Header() {
+	const history = useHistory();
 	const { user } = useContext(UserContext);
 	const [isSignInModalOpen, setIsSignInModalOpen] = useState(false);
 
 	const handleOpenSignInModal = () => setIsSignInModalOpen(true);
 	const handleCloseSignInModal = () => setIsSignInModalOpen(false);
-	const handleClickDashBoard = () => (window.location.href = '../dashboard');
+	const handleClickDashBoard = () => history.push('/dashboard');
 	const handleSignOut = () => {
 		const confirm = window.confirm('로그아웃 하시겠습니까?');
 		if (!confirm) return;

--- a/cocode/src/containers/DashBoard/ProjectCardList/index.js
+++ b/cocode/src/containers/DashBoard/ProjectCardList/index.js
@@ -15,7 +15,7 @@ function ProjectCardList() {
 				<Style.CoconutCount>{coconuts.length}</Style.CoconutCount>
 			</Style.Title>
 			<Style.CardList>
-				<Link to="/project">
+				<Link to="/project/new">
 					<CreateButton />
 				</Link>
 				{coconuts.map((coconut, index) => (

--- a/cocode/src/containers/Home/Main/index.js
+++ b/cocode/src/containers/Home/Main/index.js
@@ -28,7 +28,7 @@ function Description() {
 	return (
 		<Styled.Description>
 			<Title />
-			<Link to="/project">
+			<Link to="/project/new">
 				<OpenButton />
 			</Link>
 		</Styled.Description>


### PR DESCRIPTION
## 간단한 요약 설명
프로젝트 카드 및 open 드롭다운 아이템 클릭시 해당 프로젝트의 에디터 이동 기능을 구현했습니다.
프로젝트 생성 버튼 클릭시 'project/new' 로 이동하게 했습니다.

이제 리액트 초기 템플릿 만들게요 ~! 


## 관련 이슈
close #19
close #20 
#15 
#10
