### PR TITLE
프로젝트 페이지 디펜던시 탭 컨테이너 검색 결과 노출 

### DIFF
--- a/cocode/src/apis/Project.js
+++ b/cocode/src/apis/Project.js
@@ -7,4 +7,11 @@ function getProjectInfoAPICreator(projectId) {
 	};
 }
 
-export { getProjectInfoAPICreator };
+function getDenpendencyList(name) {
+	return {
+		url: `${API.dependency(name)}`,
+		method: 'get'
+	};
+}
+
+export { getProjectInfoAPICreator, getDenpendencyList };

--- a/cocode/src/components/Project/DependencySearch/index.js
+++ b/cocode/src/components/Project/DependencySearch/index.js
@@ -1,23 +1,43 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import * as Styled from './style';
 
 import DependencySearchItem from 'components/Project/DependencySearchItem';
 
-import { dependencySearchList } from './dummy';
+import { KEY_CODE_ENTER } from 'constants/keyCode';
+import { getDenpendencyList } from 'apis/Project';
+import useFetch from 'hooks/useFetch';
 
 function DependencySearch() {
+	const searchInput = useRef(false);
+	const [{ data }, setRequest] = useFetch({});
+	const [dependencySearchList, setDependencySearchList] = useState([]);
+
+	const handleSearchTypingEnd = () => {
+		const name = searchInput.current.value;
+		setRequest(getDenpendencyList(name));
+	};
+
+	const handleKeyDown = e => {
+		if (e.keyCode === KEY_CODE_ENTER) handleSearchTypingEnd();
+	};
+
+	useEffect(() => {
+		data && setDependencySearchList(data);
+	}, [data]);
+
 	return (
 		<article>
-			<Styled.SearchBar />
+			<Styled.SearchBar ref={searchInput} onKeyDown={handleKeyDown} />
 			<Styled.DependencySearchList>
 				{dependencySearchList.map(
-					({ name, latestVersion, versions, github, npm }, index) => {
+					({ name, version, versions, github, npm }, index) => {
 						return (
 							<DependencySearchItem
 								key={`dependency${index}`}
 								name={name}
-								latestVersion={latestVersion}
-								versions={versions}
+								latestVersion={version}
+								// 이후에 version을 받아오는 기능 구현할 예정
+								// versions={versions}
 								github={github}
 								npm={npm}
 							/>

--- a/cocode/src/components/Project/DependencySearch/style.js
+++ b/cocode/src/components/Project/DependencySearch/style.js
@@ -16,6 +16,8 @@ const SearchBar = styled.input.attrs(() => ({
 const DependencySearchList = styled.ul`
     & {
         list-style: none;
+        overflow: scroll;
+        height: 50vh;
     }
 `;
 

--- a/cocode/src/components/Project/DependencySearchItem/index.js
+++ b/cocode/src/components/Project/DependencySearchItem/index.js
@@ -11,7 +11,7 @@ function DependencySearchItem({ name, versions, github, npm }) {
         <Styled.Item>
             {name}
             <Styled.Description>
-                <DependencySelector options={versions} />
+                {/*<DependencySelector options={versions} />*/}
                 <PlusImage />
                 <GitHubLogo href={github}/>
                 <NpmLogo href={npm}/>

--- a/cocode/src/config/index.js
+++ b/cocode/src/config/index.js
@@ -14,7 +14,8 @@ const API = {
 	login: `${API_SERVER}/users/login`,
 	users: `${API_SERVER}/users`,
 	projects: `${API_SERVER}/projects`,
-	files: projectId => `${API_SERVER}/projects/${projectId}/files`
+	files: projectId => `${API_SERVER}/projects/${projectId}/files`,
+	dependency: name => `${API_SERVER}/dependency/search?name=${name}`
 };
 
 export { DEFAULT_REQUEST_OPTION, API };


### PR DESCRIPTION
## 간단한 요약 설명
디펜던시 탭에 모듈을 검색하고 엔터를 누르면 서버에 검색 결과를 요청하는 기능을 구현했습니다
향후 
1. 키 이벤트를 변경해 칠때마다 검색 결과를 노출하게 할 예정입니다.
2. pagenation 혹은 무한스크롤링을 구현할 예정입니다. 

## 관련 이슈
close #215
