### PR TITLE
프로젝트 페이지에서 서버에 프로젝트 생성 요청 구현

### DIFF
--- a/cocode/src/pages/Project/index.js
+++ b/cocode/src/pages/Project/index.js
@@ -1,5 +1,5 @@
-import React, { useReducer, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useReducer, useEffect, useState, useContext } from 'react';
+import { useParams, useHistory } from 'react-router-dom';
 import * as Styled from './style';
 
 import Header from 'containers/Common/Header';
@@ -15,13 +15,16 @@ import { fetchProjectActionCreator } from 'actions/Project';
 
 import { TAB_BAR_THEME } from 'constants/theme';
 
-import reactTemplate from 'template/objectIdMapper';
+import UserContext from 'contexts/UserContext';
 import useFetch from 'hooks/useFetch';
-import { getProjectInfoAPICreator } from 'apis/Project';
+import reactTemplate from 'template/objectIdMapper';
+import { getProjectInfoAPICreator, forkProjectAPICreator } from 'apis/Project';
 
 const DEFAULT_CLICKED_TAB_INDEX = 1;
 
 function Project() {
+	const { user } = useContext(UserContext);
+	const history = useHistory();
 	const { projectId } = useParams();
 	const [{ data, loading, error }, setRequest] = useFetch({});
 	const [isFetched, setIsFetched] = useState(false);
@@ -37,8 +40,25 @@ function Project() {
 			return;
 		}
 
-		const project = reactTemplate();
+		const name = prompt('프로젝트 이름을 입력해주세요');
+		if (!name) {
+			history.goBack();
+			return;
+		}
+
+		const project = handleForkNewCoconut(name);
 		handleSetProjectState(project);
+		history.push(`../project/${project._id}`);
+	};
+
+	const handleForkNewCoconut = name => {
+		const project = reactTemplate();
+		project.name = name;
+		project.author = user.username;
+		const forkProjectInfoAPI = forkProjectAPICreator(project);
+		setRequest(forkProjectInfoAPI);
+
+		return project;
 	};
 
 	const handleSetProjectState = project => {


### PR DESCRIPTION
## 간단한 요약 설명
현재 prompt 창으로 프로젝트 이름을 입력을 받으면
서버에 생성 요청을 보냅니다.

후에 파일 저장 기능이 구현된 후,
첫 ctrl+s에 fork 요청을 보내도록 구현할 예정입니다.

## 관련 이슈
#204 
