### PR TITLE
파일수정 API 클라이언트에 적용

### DIFF
--- a/cocode/src/apis/File.js
+++ b/cocode/src/apis/File.js
@@ -16,4 +16,12 @@ function deleteFileAPICreator(projectId, fileId, data) {
 	};
 }
 
-export { createFileAPICreator, deleteFileAPICreator };
+function updateFileAPICreator(projectId, fileId, data) {
+	return {
+		url: `${API.files(projectId)}/${fileId}`,
+		method: 'patch',
+		data
+	};
+}
+
+export { createFileAPICreator, deleteFileAPICreator, updateFileAPICreator };

--- a/cocode/src/components/Project/File/index.js
+++ b/cocode/src/components/Project/File/index.js
@@ -19,9 +19,9 @@ import { KEY_CODE_ENTER } from 'constants/keyCode';
 
 import useFetch from 'hooks/useFetch';
 
-import { deleteFileAPICreator } from 'apis/File';
+import { deleteFileAPICreator, updateFileAPICreator } from 'apis/File';
 
-import { DELETE_FILE } from 'actions/types';
+import { DELETE_FILE, UPDATE_FILE_NAME } from 'actions/types';
 
 // Constants
 const ACCEPT_DELETE_NOTIFICATION = '이 파일을 지우시겠습니까?';
@@ -52,7 +52,8 @@ function File({
 
 	// Variables
 	const successHandler = {
-		[DELETE_FILE]: handleDeleteFile
+		[DELETE_FILE]: handleDeleteFile,
+		[UPDATE_FILE_NAME]: handleEditFileName
 	};
 
 	// Functions
@@ -74,8 +75,19 @@ function File({
 		setToggleEdit(false);
 		nameEditReferenece.current.contentEditable = false;
 		const changedName = currentTarget.textContent;
-		setFileName(changedName);
-		handleEditFileName(changedName);
+
+		const updateFileId = _id;
+		const updateFileAPI = updateFileAPICreator(projectId, updateFileId, {
+			name: changedName
+		});
+
+		successHandler[UPDATE_FILE_NAME] = () => {
+			setFileName(changedName);
+			handleEditFileName(changedName);
+		};
+
+		setRequest(updateFileAPI);
+		setRequestedAPI(UPDATE_FILE_NAME);
 	};
 
 	const handleDeleteFileButtonClick = e => {
@@ -89,6 +101,7 @@ function File({
 		const deleteFileAPI = deleteFileAPICreator(projectId, deleteFileId, {
 			parentId
 		});
+
 		setRequest(deleteFileAPI);
 		setRequestedAPI(DELETE_FILE);
 	};
@@ -115,8 +128,8 @@ function File({
 	const handleSetFileState = () => {
 		if (!requestedAPI) return;
 
-		successHandler[requestedAPI](_id);
-		setRequestedAPI(null);
+		if (requestedAPI === UPDATE_FILE_NAME) successHandler[requestedAPI]();
+		if (requestedAPI === DELETE_FILE) successHandler[requestedAPI](_id);
 	};
 
 	const handleErrorResponse = () => {

--- a/cocode/src/components/Project/MonacoEditor/index.js
+++ b/cocode/src/components/Project/MonacoEditor/index.js
@@ -1,28 +1,16 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React from 'react';
 import { ControlledEditor } from '@monaco-editor/react';
 import * as Styled from './style';
 
-import ProjectContext from 'contexts/ProjectContext';
-import { updateCodeActionCreator } from 'actions/Project';
-
-function MonacoEditor({ ...props }) {
-	const { project, dispatchProject } = useContext(ProjectContext);
-	const [code, setCode] = useState('');
-
-	const handleOnChange = (_, changedCode) => {
-		setCode(changedCode);
-		const updateCodeAction = updateCodeActionCreator({
-			changedCode: changedCode
-		});
-		dispatchProject(updateCodeAction);
-	};
-
-	useEffect(() => {
-		setCode(project.editingCode);
-	}, [project.selectedFileId]);
-
+function MonacoEditor({
+	isFilesEmpty,
+	code,
+	handleEditorDidMount,
+	handleUpdateCode,
+	...props
+}) {
 	return (
-		<Styled.MonacoEditor {...props} isFilesEmpty={!project.selectedFileId}>
+		<Styled.MonacoEditor isFilesEmpty={isFilesEmpty} {...props}>
 			<ControlledEditor
 				value={code}
 				language="javascript"
@@ -30,7 +18,8 @@ function MonacoEditor({ ...props }) {
 				options={{
 					fontSize: '16px'
 				}}
-				onChange={handleOnChange}
+				onChange={handleUpdateCode}
+				editorDidMount={handleEditorDidMount}
 			/>
 		</Styled.MonacoEditor>
 	);

--- a/cocode/src/containers/Project/Editor/index.js
+++ b/cocode/src/containers/Project/Editor/index.js
@@ -6,14 +6,13 @@ import FileTabBar from 'components/Project/FileTabBar';
 import MonacoEditor from 'components/Project/MonacoEditor';
 
 import ProjectContext from 'contexts/ProjectContext';
-import {
-	updateCodeActionCreator,
-	undoUpdateCodeActionCreator
-} from 'actions/Project';
+import { updateCodeActionCreator } from 'actions/Project';
 
 import useFetch from 'hooks/useFetch';
 
 import { updateFileAPICreator } from 'apis/File';
+
+let timer;
 
 function Editor() {
 	const { projectId } = useParams();
@@ -24,7 +23,7 @@ function Editor() {
 
 	const { selectedFileId } = project;
 
-	const handleUpdateCode = (_, changedCode) => {
+	const debouncedHandlerUpdateCode = changedCode => () => {
 		setCode(changedCode);
 
 		const updateCodeAction = updateCodeActionCreator({
@@ -33,10 +32,17 @@ function Editor() {
 		dispatchProject(updateCodeAction);
 	};
 
+	const handleUpdateCode = (_, changedCode) => {
+		if (timer) clearTimeout(timer);
+
+		timer = setTimeout(debouncedHandlerUpdateCode(changedCode), 300);
+	};
+
 	const handleChangedSelectedFile = () => setCode(project.editingCode);
 
 	const handleRequestUpdateCode = () => {
 		if (!isEditorMounted) return;
+
 		const updateFileAPI = updateFileAPICreator(projectId, selectedFileId, {
 			contents: code
 		});

--- a/cocode/src/containers/Project/Editor/index.js
+++ b/cocode/src/containers/Project/Editor/index.js
@@ -1,14 +1,62 @@
 import React, { useState, useContext, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import * as Styled from './style';
 
 import FileTabBar from 'components/Project/FileTabBar';
 import MonacoEditor from 'components/Project/MonacoEditor';
 
+import ProjectContext from 'contexts/ProjectContext';
+import {
+	updateCodeActionCreator,
+	undoUpdateCodeActionCreator
+} from 'actions/Project';
+
+import useFetch from 'hooks/useFetch';
+
+import { updateFileAPICreator } from 'apis/File';
+
 function Editor() {
+	const { projectId } = useParams();
+	const { project, dispatchProject } = useContext(ProjectContext);
+	const [code, setCode] = useState(project.editingCode);
+	const [isEditorMounted, setIsEditorMounted] = useState(false);
+	const [_, setRequest] = useFetch({});
+
+	const { selectedFileId } = project;
+
+	const handleUpdateCode = (_, changedCode) => {
+		setCode(changedCode);
+
+		const updateCodeAction = updateCodeActionCreator({
+			changedCode: changedCode
+		});
+		dispatchProject(updateCodeAction);
+	};
+
+	const handleChangedSelectedFile = () => setCode(project.editingCode);
+
+	const handleRequestUpdateCode = () => {
+		if (!isEditorMounted) return;
+		const updateFileAPI = updateFileAPICreator(projectId, selectedFileId, {
+			contents: code
+		});
+		setRequest(updateFileAPI);
+	};
+
+	useEffect(handleChangedSelectedFile, [project.selectedFileId]);
+	useEffect(handleRequestUpdateCode, [code]);
+
+	const handleEditorDidMount = () => setIsEditorMounted(true);
 	return (
 		<Styled.Editor>
 			<FileTabBar />
-			<MonacoEditor className="Stretch-width" />
+			<MonacoEditor
+				isFilesEmpty={!project.selectedFileId}
+				code={code}
+				handleUpdateCode={handleUpdateCode}
+				handleEditorDidMount={handleEditorDidMount}
+				className="Stretch-width"
+			/>
 		</Styled.Editor>
 	);
 }


### PR DESCRIPTION
## 간단한 요약 설명
- 파일수정에 대한 API요청을 하도록 클라이언트 로직을 구현했습니다.
- 파일 이름 수정, 파일 위치 변경, 코드 수정 총 3가지 경우가 존재합니다.
- 코드 수정시 event debounce기법을 적용하여 마지막 event발생 후 0.3초 이후에 요청을 보내도록 했습니다.