### PR TITLE
대시보드의 z-index 추가

### DIFF
--- a/cocode/src/components/Common/DropDownMenu/style.js
+++ b/cocode/src/components/Common/DropDownMenu/style.js
@@ -20,6 +20,7 @@ const DropDownList = styled.ul`
 		
 		margin: 0;
 		padding: 0;
+		z-index: 5;
 	}
 `;
 


### PR DESCRIPTION
## 간단한 요약 설명
프로젝트 페이지에서 오버레이가 발생한 경우
대시보드가 오버레이영역의 밑에 겹쳐져서 버튼이 클릭되지 않는 버그를
대시보드의 z-index를 추가하여 해결했습니다.

## 관련 이슈
* close #233