### PR TITLE
[육지수] w6_리뷰요청_Coconut page 분리 및 indexedDB 사용

### DIFF
--- a/cocode/src/components/Project/Browser/index.js
+++ b/cocode/src/components/Project/Browser/index.js
@@ -1,0 +1,166 @@
+import React, {
+	useState,
+	useEffect,
+	useContext,
+	useRef,
+	useCallback
+} from 'react';
+import { useParams } from 'react-router-dom';
+import * as Styled from './style';
+
+import CoconutSpinner from 'components/Common/CoconutSpinner';
+
+import ProjectContext from 'contexts/ProjectContext';
+
+import { installDependencyActionCreator } from 'actions/Project';
+
+import { updateFileAPICreator } from 'apis/File';
+
+import useFetch from 'hooks/useFetch';
+
+import getUpdatedPackageJSON from 'pages/Project/getUpdatedPackageJSON';
+
+// Constants
+const MIN_WAIT_TIME = 1500;
+const UPDATE_CODE = 'updateFile';
+const INSTALL_DEPENDENCY = 'installDependency';
+const CREATE_NEW_PROJECT = 'createNewProject';
+
+function BrowserV2({ ...props }) {
+	const { projectId } = useParams();
+
+	const { project, dispatchProject } = useContext(ProjectContext);
+	const [{ data, error }, setRequest] = useFetch({});
+	const [isReadyToReceiveMessage, setIsReadyToReceiveMessage] = useState(
+		false
+	);
+	const [dependency, setDependency] = useState(undefined);
+	const [isBuildingCoconut, setIsBuildingCoconut] = useState(true);
+	const iframeReference = useRef();
+
+	const { files, root, dependencyInstalling } = project;
+
+	const handleComponentDidMount = () => {
+		window.addEventListener('message', receiveMsgFromChild);
+	};
+
+	const receiveMsgFromChild = e => {
+		const { command, dependency } = e.data;
+
+		const cocodeActions = {
+			buildEnd,
+			installDependency
+		};
+		cocodeActions[command] && cocodeActions[command](dependency);
+	};
+
+	const buildEnd = () => setIsBuildingCoconut(false);
+
+	const installDependency = dependency => {
+		setDependency(dependency);
+
+		if (projectId === 'new') {
+			endInstallDependency(dependency);
+			return;
+		}
+
+		const {
+			newPackageJSONContents,
+			packageJSONFileId
+		} = getUpdatedPackageJSON(files, root, dependency);
+
+		const updateFileAPI = updateFileAPICreator(
+			projectId,
+			packageJSONFileId,
+			{
+				contents: newPackageJSONContents
+			}
+		);
+		setRequest(updateFileAPI);
+	};
+
+	const endInstallDependency = useCallback(dependency => {
+		setTimeout(() => {
+			const installDependencyAction = installDependencyActionCreator({
+				moduleName: dependency.name,
+				moduleVersion: dependency.version
+			});
+			dispatchProject(installDependencyAction);
+		}, MIN_WAIT_TIME);
+	});
+
+	const handleUpdateDependency = () => {
+		if (!isReadyToReceiveMessage) return;
+		if (!dependencyInstalling) return;
+
+		const dependency = dependencyInstalling;
+		const data = {
+			command: INSTALL_DEPENDENCY,
+			dependency
+		};
+		iframeReference.current.contentWindow.postMessage(data, '*');
+	};
+
+	const handleUpdateFile = () => {
+		if (!isReadyToReceiveMessage) return;
+
+		const data = {
+			command: UPDATE_CODE,
+			fileId: project.selectedFileId,
+			file: project.files[project.selectedFileId]
+		};
+
+		iframeReference.current.contentWindow.postMessage(data, '*');
+	};
+
+	const handleSuccessResponse = () => {
+		if (!data) return;
+
+		setDependency(undefined);
+		endInstallDependency(dependency);
+	};
+
+	const handleErrorResponse = () => {
+		if (!error) return;
+		console.log('error: update package json');
+	};
+
+	const handleIframeOnLoad = useCallback(() => {
+		setIsReadyToReceiveMessage(true);
+
+		if (projectId === 'new') {
+			const data = {
+				command: CREATE_NEW_PROJECT,
+				project
+			};
+
+			iframeReference.current.contentWindow.postMessage(data, '*');
+		}
+	}, [project]);
+
+	useEffect(handleComponentDidMount, []);
+	useEffect(handleUpdateDependency, [dependencyInstalling]);
+	useEffect(handleUpdateFile, [files]);
+
+	useEffect(handleSuccessResponse, [data]);
+	useEffect(handleErrorResponse, [error]);
+
+	return (
+		<Styled.Frame>
+			{isBuildingCoconut && (
+				<Styled.LoadingOverlay>
+					<CoconutSpinner />
+					<p>Please wait to build complete...</p>
+				</Styled.LoadingOverlay>
+			)}
+			<Styled.BrowserV2
+				ref={iframeReference}
+				src={`/coconut/${projectId}`}
+				onLoad={handleIframeOnLoad}
+				{...props}
+			></Styled.BrowserV2>
+		</Styled.Frame>
+	);
+}
+
+export default BrowserV2;

--- a/cocode/src/components/Project/Browser/style.js
+++ b/cocode/src/components/Project/Browser/style.js
@@ -1,0 +1,64 @@
+import styled from 'styled-components';
+
+const Frame = styled.div`
+	& {
+		position: relative;
+	}
+`;
+const ErrorDisplay = styled.div`
+	& {
+		position: absolute;
+		z-index: ${({ errorDescription }) => (errorDescription ? 1 : -1)};
+		overflow-x: scroll;
+
+		padding: 1rem;
+
+		height: 100%;
+		width: 100%;
+
+		background-color: ${({ errorDescription }) =>
+			errorDescription ? 'rgba(0, 0, 0, 0.7)' : 'transparent'};
+
+		font-size: 2rem;
+		font-weight: lighter;
+	}
+`;
+
+const BrowserV2 = styled.iframe`
+	& {
+		position: absolute;
+
+		height: 100%;
+		width: 100%;
+
+		background-color: white;
+	}
+`;
+
+const LoadingOverlay = styled.section`
+	& {
+		position: fixed;
+		top: 12vh;
+		left: 0;
+		z-index: 100;
+
+		height: 100vh;
+		width: 100vw;
+
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+
+		background-color: black;
+
+		p {
+			margin-top: 2rem;
+
+			font-size: 3rem;
+			font-weight: lighter;
+		}
+	}
+`;
+
+export { Frame, ErrorDisplay, BrowserV2, LoadingOverlay };

--- a/cocode/src/indexedDB/index.js
+++ b/cocode/src/indexedDB/index.js
@@ -1,0 +1,156 @@
+const NOT_SUPPORT_WARNING =
+	'이 브라우저에서는 지원하지 않습니다. 크롬으로 접속해주세요!';
+const IDB_PERMISSION_WARNING = 'DB 생성 권한이 없습니다.';
+const HANDLE_INDEXEDDB_ERROR = 'Fail: handle indexdb';
+
+function checkSupportBrowser() {
+	if (window.indexedDB) return true;
+
+	window.alert(NOT_SUPPORT_WARNING);
+	return false;
+}
+
+function connectToIDB({
+	idbName,
+	version = 1,
+	successHandler,
+	failHandler = error => console.log(error)
+}) {
+	return new Promise((resolve, reject) => {
+		const request = window.indexedDB.open(idbName, version);
+
+		request.onupgradeneeded = ({ target }) => {
+			const db = target.result;
+			db.createObjectStore(idbName);
+		};
+
+		request.onsuccess = () => resolve(request);
+		request.onerror = () => reject(IDB_PERMISSION_WARNING);
+	})
+	.then(({ result }) => {
+		const connnection = result;
+		connnection.onerror = ({ target }) =>
+			console.log(`Database error: ${target.errorCode}`);
+		successHandler(connnection);
+	})
+	.catch(failHandler);
+}
+
+function getData({
+	idbConnection,
+	key,
+	successHandler,
+	failHandler = error => console.log(error)
+}) {
+	return new Promise((resolve, reject) => {
+		const idbName = idbConnection.name;
+		const transaction = idbConnection.transaction([idbName]);
+
+		transaction.oncomplete = () => resolve(true);
+		transaction.onerror = () => reject(HANDLE_INDEXEDDB_ERROR);
+
+		const objectStore = transaction.objectStore(idbName);
+		const request = objectStore.get(key);
+
+		request.onsuccess = ({ target }) => resolve(target.result);
+		request.onerror = () => reject(true);
+	})
+	.then(result => successHandler(result))
+	.catch(failHandler);
+}
+
+function updateData({
+	idbConnection,
+	strategy = 'readwrite',
+	key,
+	value,
+	successHandler,
+	failHandler = error => console.log(error)
+}) {
+	return new Promise((resolve, reject) => {
+		const idbName = idbConnection.name;
+		const transaction = idbConnection.transaction([idbName], strategy);
+
+		transaction.oncomplete = () => resolve(true);
+		transaction.onerror = () => reject(HANDLE_INDEXEDDB_ERROR);
+
+		const objectStore = transaction.objectStore(idbName);
+		const request = objectStore.put(value, key);
+
+		request.onerror = () => reject(true);
+	})
+	.then(result => successHandler(result))
+	.catch(failHandler);
+}
+
+function removeData({
+	idbConnection,
+	strategy = 'readwrite',
+	key,
+	successHandler,
+	failHandler = error => console.log(error)
+}) {
+	return new Promise((resolve, reject) => {
+		const idbName = idbConnection.name;
+		const transaction = idbConnection.transaction([idbName], strategy);
+
+		transaction.oncomplete = () => resolve(true);
+		transaction.onerror = () => reject(HANDLE_INDEXEDDB_ERROR);
+
+		const objectStore = transaction.objectStore(idbName);
+		const request = objectStore.delete(key);
+
+		request.onerror = () => reject(true);
+	})
+	.then(result => successHandler(result))
+	.catch(failHandler);
+}
+
+function getDataFilterByKeys({
+	idbConnection,
+	filterKeys,
+	successHandler,
+	failHandler = error => console.log(error)
+}) {
+	return new Promise((resolve, reject) => {
+		const idbName = idbConnection.name;
+		const transaction = idbConnection.transaction([idbName]);
+
+		transaction.oncomplete = () => resolve(true);
+		transaction.onerror = () => reject(HANDLE_INDEXEDDB_ERROR);
+
+		const objectStore = transaction.objectStore(idbName);
+		const cursorRequest = objectStore.openCursor();
+
+		const result = {};
+		let cloneFilterKeys = filterKeys.map(item => item);
+
+		cursorRequest.onsuccess = ({ target }) => {
+			const cursor = target.result;
+			if (!cursor || cloneFilterKeys.length === 0) {
+				resolve({ installed: result, needToInstall: cloneFilterKeys });
+				return;
+			}
+
+			const { key, value } = cursor;
+			const isExist = cloneFilterKeys.some(item => key === item);
+			if (isExist) {
+				cloneFilterKeys = cloneFilterKeys.filter(item => key !== item);
+				result[key] = value;
+			}
+			cursor.continue();
+		};
+		cursorRequest.onerror = () => reject(true);
+	})
+	.then(result => successHandler(result))
+	.catch(failHandler);
+}
+
+export {
+	checkSupportBrowser,
+	connectToIDB,
+	getData,
+	updateData,
+	removeData,
+	getDataFilterByKeys
+};

--- a/cocode/src/pages/Coconut/index.js
+++ b/cocode/src/pages/Coconut/index.js
@@ -1,0 +1,388 @@
+import React, { useState, useEffect, useReducer, useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+import * as Styled from './style';
+
+import CoconutSpinner from 'components/Common/CoconutSpinner';
+import Logo from 'components/Common/Logo';
+
+import ProjectReducer from 'reducers/ProjectReducer';
+
+import * as bundler from 'bundler';
+
+import {
+	checkSupportBrowser,
+	connectToIDB,
+	updateData,
+	getData,
+	getDataFilterByKeys
+} from 'indexedDB';
+
+import useFetch from 'hooks/useFetch';
+
+import { getModule } from 'apis/Dependency';
+import { getProjectInfoAPICreator } from 'apis/Project';
+
+import {
+	fetchProjectActionCreator,
+	cloneProjectActionCreator
+} from 'actions/Project';
+
+const COCONUT_IDBNAME = 'Coconut';
+const DEPENDENCY_IDBNAME = 'Dependency';
+
+const initilaBuildState = {
+	state: 'loading',
+	description: 'Please wait to build complete...'
+};
+
+const INSTALL_DEPENDENCY = 'installDependency';
+const BUILD_END = 'buildEnd';
+const CREATE_NEW_PROJECT = 'createNewProject';
+
+function Coconut() {
+	const { projectId } = useParams();
+
+	const [fetchProjectRequest, setFetchProjectRequest] = useFetch({});
+	const [dependencyRequest, setDependencyRequest] = useFetch({});
+	const [project, dispatchProject] = useReducer(ProjectReducer, undefined);
+	const [projectIDBConnection, setProjectIDBConnection] = useState(undefined);
+	const [dependencyIDBConnection, setDependencyIDBConnection] = useState(
+		undefined
+	);
+	const [needToInstallDependency, setNeedToInstallDependency] = useState(
+		undefined
+	);
+	const [isReadyToBuild, setIsReadyToBuild] = useState(false);
+
+	const [messageFromCocode, setMessageFromCocode] = useState(undefined);
+
+	const [buildState, setBuildState] = useState(initilaBuildState);
+
+	/* Coconut Build Life cycle */
+	// Component did mount
+	const handleComponentDidMount = useCallback(() => {
+		if (!checkSupportBrowser()) return;
+		window.addEventListener('message', receiveMsgFromCocode);
+
+		const successHandler = connection => {
+			setProjectIDBConnection(connection);
+		};
+		connectToIDB({
+			idbName: COCONUT_IDBNAME,
+			successHandler
+		});
+
+		return cleanUpComponent;
+	}, []);
+
+	const cleanUpComponent = useCallback(() => {
+		projectIDBConnection && projectIDBConnection.close();
+		dependencyIDBConnection && dependencyIDBConnection.close();
+
+		setProjectIDBConnection(undefined);
+		setDependencyIDBConnection(undefined);
+	}, [projectIDBConnection, dependencyIDBConnection]);
+
+	const receiveMsgFromCocode = useCallback(({ data }) => {
+		if (!data.command) return;
+		setMessageFromCocode(data);
+	}, []);
+
+	// Check project data in IDB
+	const handleCheckProjectData = useCallback(() => {
+		if (!projectIDBConnection) return;
+		if (projectId === 'new') {
+			return;
+		}
+
+		const successHandler = result => {
+			if (!result) {
+				fetchProject();
+				return;
+			}
+
+			const project = result;
+			const cloneProjectAction = cloneProjectActionCreator({ project });
+			dispatchProject(cloneProjectAction);
+		};
+		getData({
+			idbConnection: projectIDBConnection,
+			key: projectId,
+			successHandler
+		});
+	}, [projectIDBConnection]);
+
+	const fetchProject = useCallback(() => {
+		const getProjectInfoAPI = getProjectInfoAPICreator(projectId);
+		setFetchProjectRequest(getProjectInfoAPI);
+	}, []);
+
+	// Response about fetch project to server
+	const handleFetchProjectResponse = useCallback(() => {
+		const { data, error } = fetchProjectRequest;
+		if (error) {
+			window.parent.postMessage({ command: BUILD_END }, '*');
+			setBuildState({
+				state: 'error',
+				description: 'Error: fail to fetch project'
+			});
+			return;
+		}
+
+		if (!data) return;
+
+		const fetchProjectAction = fetchProjectActionCreator({ project: data });
+		dispatchProject(fetchProjectAction);
+	}, [fetchProjectRequest]);
+
+	// After project data fetch
+	const handleProjectFetched = useCallback(() => {
+		if (!project) return;
+		if (
+			messageFromCocode &&
+			messageFromCocode.command !== CREATE_NEW_PROJECT
+		) {
+			setMessageFromCocode(undefined);
+			buildProject();
+			return;
+		}
+
+		const successHandler = connection => {
+			setDependencyIDBConnection(connection);
+		};
+		connectToIDB({
+			idbName: DEPENDENCY_IDBNAME,
+			successHandler
+		});
+	}, [project, messageFromCocode]);
+
+	// Check dependency in IDB
+	const handleCheckDependency = useCallback(() => {
+		if (!dependencyIDBConnection) return;
+		const { dependency } = project;
+
+		const successHandler = result => {
+			const { installed, needToInstall } = result;
+
+			Object.entries(installed).forEach(([_, value]) => {
+				Object.entries(value).forEach(([key, value]) => {
+					fileSystem[key] = value;
+				});
+			});
+
+			setNeedToInstallDependency(needToInstall);
+		};
+
+		const filterKeys = Object.values(dependency).map(({ name, version }) =>
+			JSON.stringify([name, version])
+		);
+
+		getDataFilterByKeys({
+			idbConnection: dependencyIDBConnection,
+			filterKeys,
+			successHandler
+		});
+	}, [dependencyIDBConnection]);
+
+	// After check dependency : install dependency from server
+	const handleInstallDependency = useCallback(() => {
+		if (!needToInstallDependency) return;
+		if (!needToInstallDependency.length) {
+			setIsReadyToBuild(true);
+			setNeedToInstallDependency(undefined);
+			return;
+		}
+
+		const [name, version] = JSON.parse(needToInstallDependency[0]);
+		const getModuleAPI = getModule(name, version);
+		setDependencyRequest(getModuleAPI);
+	}, [needToInstallDependency]);
+
+	// Response from server, when install dependency
+	const handleInstallDependencyResponse = useCallback(() => {
+		const { data, error } = dependencyRequest;
+		if (error) {
+			window.parent.postMessage({ command: BUILD_END }, '*');
+			setBuildState({
+				state: 'error',
+				description: 'Error: fail to install dependency'
+			});
+			return;
+		}
+
+		if (!data) return;
+
+		const [key] = needToInstallDependency;
+		updateDependencyToIDB(key, data);
+
+		Object.entries(data).forEach(([key, value]) => {
+			fileSystem[key] = value;
+		});
+		setNeedToInstallDependency(
+			needToInstallDependency.filter((_, index) => index !== 0)
+		);
+	}, [dependencyRequest, needToInstallDependency]);
+
+	const updateDependencyToIDB = useCallback(
+		(key, value) => {
+			const successHandler = () => {
+				/* success to update IDB */
+			};
+			updateData({
+				idbConnection: dependencyIDBConnection,
+				key,
+				value,
+				successHandler
+			});
+		},
+		[dependencyIDBConnection]
+	);
+
+	// Build project
+	const handleBuildProject = useCallback(() => {
+		if (!isReadyToBuild) return;
+		buildProject();
+	}, [isReadyToBuild]);
+
+	const buildProject = useCallback(() => {
+		setBuildState(initilaBuildState);
+		const { files, root } = project;
+
+		const rootPath = files[root].path;
+		if (project) fileParser(rootPath, root);
+
+		try {
+			bundler.init();
+			bundler.require('./index.js');
+
+			setBuildState(undefined);
+		} catch (error) {
+			setBuildState({
+				state: 'build error',
+				description: error.stack
+			});
+		}
+
+		window.parent.postMessage({ command: BUILD_END }, '*');
+		setIsReadyToBuild(false);
+	}, [project]);
+
+	const fileParser = useCallback(
+		(path, id) => {
+			const { files } = project;
+
+			if (files[id].type !== 'directory') {
+				fileSystem[path] = {
+					contents: files[id].contents
+				};
+				delete exports[path];
+			} else if (files[id].child) {
+				files[id].child.forEach(id => {
+					const path = files[id].path;
+					fileParser(path, id);
+				});
+			}
+		},
+		[project]
+	);
+
+	const handleMessageFromCocode = useCallback(() => {
+		if (!messageFromCocode) return;
+
+		const { command } = messageFromCocode;
+		const coconutActions = {
+			updateFile,
+			installDependency,
+			createNewProject
+		};
+		coconutActions[command] && coconutActions[command]();
+	}, [messageFromCocode]);
+
+	const updateFile = useCallback(() => {
+		console.log('update');
+		const { files } = project;
+		const { fileId, file } = messageFromCocode;
+
+		const newProject = {
+			...project,
+			files: {
+				...files,
+				[fileId]: file
+			}
+		};
+
+		const cloneProjectAction = cloneProjectActionCreator({
+			project: newProject
+		});
+		dispatchProject(cloneProjectAction);
+
+		window.parent.postMessage({ command: BUILD_END }, '*');
+	}, [project, messageFromCocode]);
+
+	const installDependency = useCallback(() => {
+		const { dependency } = messageFromCocode;
+
+		const successHandler = result => {
+			const { installed, needToInstall } = result;
+
+			Object.entries(installed).forEach(([_, value]) => {
+				Object.entries(value).forEach(([key, value]) => {
+					fileSystem[key] = value;
+				});
+			});
+
+			const data = {
+				command: INSTALL_DEPENDENCY,
+				dependency
+			};
+			window.parent.postMessage(data, '*');
+			setNeedToInstallDependency(needToInstall);
+		};
+
+		const filterKeys = Object.values({
+			dependency
+		}).map(({ name, version }) => JSON.stringify([name, version]));
+
+		getDataFilterByKeys({
+			idbConnection: dependencyIDBConnection,
+			filterKeys,
+			successHandler
+		});
+	}, [messageFromCocode]);
+
+	const createNewProject = useCallback(() => {
+		if (project) return;
+
+		const cloneProjectAction = cloneProjectActionCreator({
+			project: messageFromCocode.project
+		});
+		dispatchProject(cloneProjectAction);
+	}, [project, messageFromCocode]);
+
+	useEffect(handleComponentDidMount, []);
+	useEffect(handleCheckProjectData, [projectIDBConnection]);
+	useEffect(handleFetchProjectResponse, [fetchProjectRequest]);
+	useEffect(handleProjectFetched, [project]);
+	useEffect(handleCheckDependency, [dependencyIDBConnection]);
+	useEffect(handleInstallDependency, [needToInstallDependency]);
+	useEffect(handleInstallDependencyResponse, [dependencyRequest]);
+	useEffect(handleBuildProject, [isReadyToBuild]);
+
+	useEffect(handleMessageFromCocode, [messageFromCocode]);
+
+	return (
+		<>
+			<Styled.ResetStyle />
+			{buildState && (
+				<Styled.BuildStateOverlay>
+					{buildState.state === 'loading' && <CoconutSpinner />}
+					{buildState.state === 'error' && <Logo />}
+					<p className="Is-build-error">{buildState.description}</p>
+				</Styled.BuildStateOverlay>
+			)}
+			<div id="coconut-root" />
+		</>
+	);
+}
+
+export default Coconut;

--- a/cocode/src/pages/Coconut/style.js
+++ b/cocode/src/pages/Coconut/style.js
@@ -1,0 +1,44 @@
+import styled from 'styled-components';
+import { createGlobalStyle } from 'styled-components';
+
+const ResetStyle = createGlobalStyle`
+    
+    html {
+        background-color: white;
+        color: black;
+    }
+    
+    button {
+        color: black;
+    }
+`;
+
+const BuildStateOverlay = styled.div`
+	& {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+
+		overflow: scroll;
+
+		width: 100%;
+		height: 100%;
+
+		background-color: black;
+		color: white;
+
+		p {
+			margin: 1rem;
+
+			font-size: 2rem;
+			font-weight: lighter;
+		}
+
+		.Is-build-error {
+			font-size: 1rem;
+		}
+	}
+`;
+
+export { ResetStyle, BuildStateOverlay };


### PR DESCRIPTION
### 안녕하세요 리뷰어님!
4조의 육지수라고 합니다!
코드리뷰를 너무 늦게 올리게되어 죄송합니다...
저번주에 해주신 코드리뷰를 보고 많은 고민을 하게되고 마지막 남은 한 주 동안 전반적인 리팩토링을 하면서 reducer를 쪼개보기로 팀원들끼리 협의했습니다!
그외에도 남겨주신 코멘트들 덕분에 코드에 대해서 많은 생각을 하게 되었습니다.
감사합니다!

## 🏃‍♂️ 리뷰어님 참고사항
### 🥥 우리 프로젝트 간단 소개
저희 프로젝트는 [codesandbox](https://codesandbox.io) clone project입니다.
codesandbox는 웹에서 통합개발환경을 이용할 수 있는 서비스 입니다.

저희 프로젝트의 현재 배포 사이트는 http://www.cocode.site로 접속하실 수 있습니다!

앗 그리고 저희는 사용자가 만든 프로젝트 하나 하나를 Coconut 🥥이라고 칭하고 있습니다!

### 🥥 나의 이번주 상황
저는 이번주에 프로젝트 페이지에서 프로젝트가 build 된 결과를 확인 하는 영역을 iframe으로 교체하는 작업을 수행했습니다.
이 작업으로 인해 사용자가 [자신이 작업한 프로젝트가 빌드된 페이지에 접속할 수 있는 Link](http://www.cocode.site/coconut/5df49c00d0ab6bd22a71a583)를 제공할 수 있습니다.

또한 build 시간 단축을 위해 indexedDB에 project와 dependency를 캐싱하는 코드를 작성했습니다.
project build 시에 indexedDB를 먼저 탐색하여 server와의 통신을 최대한 줄여보도록 했습니다.


## ❓리뷰어님께 드리고 싶은 질문
### 🥥 1. 현재 Coconut page가 300줄이 넘어서 이를 custom hook으로 분리할 계획입니다.
project, dependency, build 과정을 다루는 hook 그리고 부모 iframe으로부터 message를 받는 hook으로 분리할 생각입니다.
```
└── cocode
       └── src
            └── pages
                   └── Coconut
                          └── index.js
                          └── style.js
                          └── useFetchProject.js
                          └── useFetchDependency.js
                          └── useBuildProject.js
                          └── useReceiveMessageFromCocode.js
```

혹시 더 좋은 분리 방법이 있으면 알려주시면 감사하겠습니다!

### 🥥 2. indexedDB 도입
client side 캐싱을 위해 indexedDB를 사용했습니다.
캐싱방법을 위해 조사를 하던 중 새로 알게 된 방법이고 사용하는 코드가 복잡하여 이를 한번 감싸주는 wrapper module을 자체적으로 구현해보았습니다.
```
└── indexedDB
       └── index.js
```

구현한 코드에 부족한 부분이 있는지 알려주시면 감사하겠습니다!

# 저희 팀의 코드리뷰에 귀중한 시간 내주셔서 감사합니다! 즐거운 주말보내세요! 🎉