### PR TITLE
fix: #269 코드 저장시 가입이 안되어있다고 뜨는 에러 해결

### DIFF
--- a/cocode/src/containers/Project/Editor/index.js
+++ b/cocode/src/containers/Project/Editor/index.js
@@ -57,7 +57,7 @@ function Editor({ handleForkCoconut }) {
 		const { files, selectedFileId } = project;
 		if (!files[selectedFileId].isEditing) return;
 
-		if (user.username !== project.author) {
+		if (!user || user.username !== project.author) {
 			handleForkCoconut();
 			return;
 		}

--- a/cocode/src/containers/Project/Editor/index.js
+++ b/cocode/src/containers/Project/Editor/index.js
@@ -50,6 +50,8 @@ function Editor({ handleForkCoconut }) {
 		setRequest(updateFileAPI);
 	};
 
+	const isNotMyProject = !user || user.username !== project.author;
+
 	const handleOnKeyDown = e => {
 		if (!isPressCtrlAndS(e)) return;
 
@@ -57,7 +59,7 @@ function Editor({ handleForkCoconut }) {
 		const { files, selectedFileId } = project;
 		if (!files[selectedFileId].isEditing) return;
 
-		if (!user || user.username !== project.author) {
+		if (isNotMyProject) {
 			handleForkCoconut();
 			return;
 		}

--- a/cocode/src/pages/Project/index.js
+++ b/cocode/src/pages/Project/index.js
@@ -39,7 +39,8 @@ function Project() {
 	const [project, dispatchProject] = useReducer(ProjectReducer, {});
 
 	const handleForkCoconut = () => {
-		const parsedProject = parseProject(project, user);
+		const username = user ? user.username : 'anonymous';
+		const parsedProject = parseProject(project, username);
 		const forkProjectInfoAPI = forkProjectAPICreator(parsedProject);
 		setRequest(forkProjectInfoAPI);
 

--- a/cocode/src/pages/Project/parseProject.js
+++ b/cocode/src/pages/Project/parseProject.js
@@ -1,6 +1,6 @@
 import copyProject from 'template/copyProject';
 
-const parseProject = (project, user) => {
+const parseProject = (project, username) => {
 	const { dependency, entry, name, root, _id } = project;
 	const projectInfo = JSON.parse(
 		JSON.stringify({ dependency, entry, name, root, _id })
@@ -12,7 +12,7 @@ const parseProject = (project, user) => {
 	});
 	const parsingProject = copyProject({ ...projectInfo, files });
 
-	parsingProject.author = user.username;
+	parsingProject.author = username;
 
 	return parsingProject;
 };

--- a/cocode/src/pages/Project/parseProject.js
+++ b/cocode/src/pages/Project/parseProject.js
@@ -10,11 +10,11 @@ const parseProject = (project, username) => {
 		const { child, name, projectId, type, _id, contents } = file;
 		files.push({ child, name, projectId, type, _id, contents });
 	});
-	const parsingProject = copyProject({ ...projectInfo, files });
+	const parsedProject = copyProject({ ...projectInfo, files });
 
-	parsingProject.author = username;
+	parsedProject.author = username;
 
-	return parsingProject;
+	return parsedProject;
 };
 
 export default parseProject;


### PR DESCRIPTION
## 간단한 요약 설명
코드 저장시 떴던 cannot read property 'username' of undefined 라는 에러를
해결했습니다. 해당 에러는 가입이 안된 사용자가 프로젝트를 생성하고 저장할 때 발생했고,
user에 null이어서 username을 받아올 수 없어서 생긴 오류였습니다.

user가 falsy인 경우를 추가하여 해결했습니다

## 관련 이슈
close #269 