### PR TITLE
프로젝트 및 라이브 페이지에서 헤더 수정

### DIFF
--- a/cocode/src/constants/theme.js
+++ b/cocode/src/constants/theme.js
@@ -6,6 +6,7 @@ const DEFAULT_THEME = {
 	textColor: '#ffffff',
 
 	exceptHeaderHeight: '88vh',
+	headerMinHeight: '9vh',
 	headerHeight: '12vh'
 };
 

--- a/cocode/src/containers/Common/Header/index.js
+++ b/cocode/src/containers/Common/Header/index.js
@@ -12,7 +12,7 @@ import LoginModalBody from 'components/Common/LoginModalBody';
 
 import UserContext from 'contexts/UserContext';
 
-function Header() {
+function Header({ name }) {
 	const history = useHistory();
 	const { user } = useContext(UserContext);
 	const [isSignInModalOpen, setIsSignInModalOpen] = useState(false);
@@ -42,10 +42,8 @@ function Header() {
 			<Link to="/">
 				<Logo />
 			</Link>
-			{/* <Link to="/history">
-				<Styled.HeaderCategory>History</Styled.HeaderCategory>
-			</Link> */}
-			<Styled.HeaderRightSideArea>
+			<Styled.ProjectName>{name || ''}</Styled.ProjectName>
+			<div>
 				{user ? (
 					<UserProfile
 						username={user.username}
@@ -67,7 +65,7 @@ function Header() {
 						)}
 					</>
 				)}
-			</Styled.HeaderRightSideArea>
+			</div>
 		</Styled.Header>
 	);
 }

--- a/cocode/src/containers/Common/Header/index.js
+++ b/cocode/src/containers/Common/Header/index.js
@@ -38,7 +38,7 @@ function Header({ name }) {
 	];
 
 	return (
-		<Styled.Header>
+		<Styled.Header isMinHeight={name}>
 			<Link to="/">
 				<Logo />
 			</Link>

--- a/cocode/src/containers/Common/Header/style.js
+++ b/cocode/src/containers/Common/Header/style.js
@@ -7,7 +7,8 @@ const Header = styled.header`
 		justify-content: space-between;
 		align-items: center;
 
-		height: ${({ theme }) => theme.headerHeight};
+		height: ${({ theme, isMinHeight }) =>
+			isMinHeight ? theme.headerMinHeight : theme.headerHeight};
 
 		background-color: ${({ theme }) => theme.backgroundColor};
 		padding: 2rem 2.3rem;

--- a/cocode/src/containers/Common/Header/style.js
+++ b/cocode/src/containers/Common/Header/style.js
@@ -4,7 +4,7 @@ const Header = styled.header`
 	& {
 		display: flex;
 		flex-direction: row;
-		justify-content: flex-start;
+		justify-content: space-between;
 		align-items: center;
 
 		height: ${({ theme }) => theme.headerHeight};
@@ -14,22 +14,9 @@ const Header = styled.header`
 	}
 `;
 
-const HeaderCategory = styled.button`
+const ProjectName = styled.div`
 	& {
-		margin-left: 1.5rem;
-
-		font-size: 1.4rem;
-		font-weight: 100;
-	}
-
-	&:hover {
-		color: ${({ theme }) => theme.mainColor};
-	}
-`;
-
-const HeaderRightSideArea = styled.div`
-	& {
-		margin-left: auto;
+		font-size: 1.3rem;
 	}
 `;
 
@@ -44,4 +31,4 @@ const SignInButton = styled.button`
 	}
 `;
 
-export { Header, SignInButton, HeaderCategory, HeaderRightSideArea };
+export { Header, SignInButton, ProjectName };

--- a/cocode/src/pages/Live/index.js
+++ b/cocode/src/pages/Live/index.js
@@ -140,7 +140,7 @@ function Live() {
 				setClickedTabIndex
 			}}
 		>
-			<Header />
+			<Header name={project.name || ''}/>
 			{isFetched && (
 				<Styled.Main>
 					<TabBar theme={TAB_BAR_THEME} />

--- a/cocode/src/pages/Live/index.js
+++ b/cocode/src/pages/Live/index.js
@@ -140,7 +140,7 @@ function Live() {
 				setClickedTabIndex
 			}}
 		>
-			<Header name={project.name || ''}/>
+			<Header name={project.name}/>
 			{isFetched && (
 				<Styled.Main>
 					<TabBar theme={TAB_BAR_THEME} />

--- a/cocode/src/pages/Live/style.js
+++ b/cocode/src/pages/Live/style.js
@@ -5,7 +5,7 @@ const Main = styled.main`
 		display: flex;
 		flex-direction: row;
 
-		height: 88vh;
+		height: 91vh;
 
 		.Project-main-stretch {
 			flex-grow: 2;

--- a/cocode/src/pages/Project/index.js
+++ b/cocode/src/pages/Project/index.js
@@ -103,7 +103,7 @@ function Project() {
 				setClickedTabIndex
 			}}
 		>
-			<Header />
+			<Header name={project.name || ''}/>
 			{isFetched && (
 				<Styled.Main>
 					<TabBar theme={TAB_BAR_THEME} />

--- a/cocode/src/pages/Project/index.js
+++ b/cocode/src/pages/Project/index.js
@@ -103,7 +103,7 @@ function Project() {
 				setClickedTabIndex
 			}}
 		>
-			<Header name={project.name || ''}/>
+			<Header name={project.name}/>
 			{isFetched && (
 				<Styled.Main>
 					<TabBar theme={TAB_BAR_THEME} />

--- a/cocode/src/pages/Project/style.js
+++ b/cocode/src/pages/Project/style.js
@@ -5,7 +5,7 @@ const Main = styled.main`
 		display: flex;
 		flex-direction: row;
 
-		height: 88vh;
+		height: 91vh;
 
 		.Project-main-stretch {
 			flex-grow: 2;


### PR DESCRIPTION
## 간단한 요약 설명
프로젝트 및 라이브 페이지에서 헤더에 해당 프로젝트 이름을 노출했습니다.
프로젝트 및 라이브 페이지에서 헤더 높이를 수정하였고,
그에 따라 메인 컨테이너의 높이 또한 수정했습니다.

## 관련 이슈
* close #23