### PR TITLE
라이브가 종료된 경우 토스트 노출

### DIFF
--- a/cocode/src/constants/notificationMessage.js
+++ b/cocode/src/constants/notificationMessage.js
@@ -15,6 +15,8 @@ const CONFIRM_DELETE_COCONUT = 'Are you delete this coconut?';
 
 const LOADING_DASHBOARD = 'Please wait to fetch coconuts';
 
+const SHUT_DOWN_LIVE_SHARE = 'The live share has been shut down';
+
 export {
 	FAIL_INSTALL_DEPENDENCY,
 	FAIL_TO_MOVE_FILE,
@@ -29,4 +31,5 @@ export {
 	CONFIRM_DELETE_FILE,
 	CONFIRM_DELETE_COCONUT,
 	LOADING_DASHBOARD,
+	SHUT_DOWN_LIVE_SHARE
 };

--- a/cocode/src/containers/Live/LiveOnTab/style.js
+++ b/cocode/src/containers/Live/LiveOnTab/style.js
@@ -73,6 +73,7 @@ const LinkURL = styled.div`
 		background-color: ${LIVE_TAB_THEME.liveLinkBGColor};
 		color: ${LIVE_TAB_THEME.liveFontColor};
 		font-size: 0.9rem;
+		user-select: text;
 	}
 `;
 

--- a/cocode/src/pages/Live/index.js
+++ b/cocode/src/pages/Live/index.js
@@ -15,6 +15,7 @@ import TabContainer from 'containers/Live/TabContainer';
 import Editor from 'containers/Live/Editor';
 import BrowserV2 from 'components/Project/BrowserV2';
 import { SplitPaneContainer } from 'components/Common/SplitPane';
+import addToast from 'components/Common/Toast';
 
 import { LiveContext, ProjectContext, UserContext } from 'contexts';
 import ProjectReducer from 'reducers/ProjectReducer';
@@ -30,6 +31,7 @@ import { TAB_BAR_THEME } from 'constants/theme';
 import { COCODE_SERVER } from 'config';
 import useFetch from 'hooks/useFetch';
 import { getProjectInfoAPICreator } from 'apis/Project';
+import { SHUT_DOWN_LIVE_SHARE } from 'constants/notificationMessage';
 
 const DEFAULT_CLICKED_TAB_INDEX = 0;
 let socket;
@@ -109,6 +111,7 @@ function Live() {
 	const handleCloseSocket = () => {
 		socket.close();
 		dispatchLive(liveOffActionCreator());
+		addToast.error(SHUT_DOWN_LIVE_SHARE);
 	};
 
 	const handleConnectSocket = useCallback(() => {


### PR DESCRIPTION
## 간단한 요약 설명
호스트가 라이브를 종료한 경우 해당 라이브에 참여한 게스트에게
해당 라이브가 종료되었음을 알려주는 토스트를 추가했습니다.
클립보드 기능을 지원하기 위해 해당 영역에 셀렉션을 설정해주었습니다.

## 관련 이슈
* close #290