### PR TITLE
로그인 성공시 이전 페이지로 리다이렉트

### DIFF
--- a/cocode/src/App.js
+++ b/cocode/src/App.js
@@ -9,7 +9,7 @@ import { getUserAPICreator } from 'apis/User';
 import { LiveStore } from 'stores';
 
 import GlobalStyle from 'components/Common/GlobalStyle';
-import { Home, DashBoard, Project, NotFound, Live, SignIn } from 'pages';
+import { Home, DashBoard, Project, NotFound, Live, SignIn, Empty } from 'pages';
 
 function App() {
 	const [user, setUser] = useState(null);
@@ -34,6 +34,7 @@ function App() {
 							</LiveStore>
 						</Route>
 						<Route path="/signin" component={SignIn} />
+						<Route path="/empty" component={Empty} />
 						<Route component={NotFound} />
 					</Switch>
 				</ThemeProvider>

--- a/cocode/src/components/Common/LoginModalBody/index.js
+++ b/cocode/src/components/Common/LoginModalBody/index.js
@@ -6,7 +6,10 @@ import { API } from 'config';
 import Github from './github.svg';
 
 function LoginModalBody() {
-	const handleClickLoginButton = () => (window.location.href = API.login);
+	const handleClickLoginButton = () => {
+		window.location.href = API.login;
+		localStorage.setItem('redirectURL', window.location.href);
+	};
 
 	return (
 		<Styled.LoginModalBody>

--- a/cocode/src/components/Common/Modal/style.js
+++ b/cocode/src/components/Common/Modal/style.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 const ModalBackGround = styled.div`
 	& {
+		z-index: 10;
 		position: fixed;
 		top: 0;
 		left: 0;

--- a/cocode/src/containers/SignIn/index.js
+++ b/cocode/src/containers/SignIn/index.js
@@ -3,12 +3,14 @@ import * as Styled from './style';
 import Github from 'components/Common/LoginModalBody/github.svg';
 import { API } from 'config';
 
+const SIGN_IN_TITLE = 'Sorry, This service requires a login.';
+
 function SignIn() {
 	const handleClickLoginButton = () => (window.location.href = API.login);
 
 	return (
 		<Styled.Wrapper>
-			<Styled.Title>Sign In</Styled.Title>
+			<Styled.Title>{SIGN_IN_TITLE}</Styled.Title>
 			<Styled.LoginButton onClick={handleClickLoginButton}>
 				<Styled.Logo src={Github} />
 				Sign In With GitHub

--- a/cocode/src/containers/SignIn/style.js
+++ b/cocode/src/containers/SignIn/style.js
@@ -23,7 +23,7 @@ const Title = styled.h1`
 	& {
 		text-align: center;
 		font-size: 3rem;
-		font-weight: 700;
+		font-weight: 100;
 	}
 `;
 

--- a/cocode/src/pages/DashBoard/index.js
+++ b/cocode/src/pages/DashBoard/index.js
@@ -25,7 +25,10 @@ function DashBoard() {
 		data && dispatchDashboard(fetchCoconutActionCreator(data));
 	};
 
-	if (!getCookie('jwt')) history.replace('../signin');
+	if (!getCookie('jwt')) {
+		localStorage.setItem('redirectURL', window.location.href);
+		history.replace('../signin');
+	}
 
 	useEffect(handleRequestGetCoconutAPI, [user]);
 	useEffect(handleSetDashBoardState, [data]);

--- a/cocode/src/pages/Empty/index.js
+++ b/cocode/src/pages/Empty/index.js
@@ -1,0 +1,18 @@
+import React, { useEffect } from 'react';
+import Header from 'containers/Common/Header';
+
+function Empty() {
+	useEffect(() => {
+		const redirectURL = localStorage.getItem('redirectURL');
+		if (redirectURL) {
+			window.location.href = redirectURL;
+			localStorage.removeItem('redirectURL');
+		}
+	}, []);
+
+	return (
+		<Header />
+	);
+}
+
+export default Empty;

--- a/cocode/src/pages/Live/index.js
+++ b/cocode/src/pages/Live/index.js
@@ -51,7 +51,10 @@ function Live() {
 	);
 	const [project, dispatchProject] = useReducer(ProjectReducer, {});
 
-	if (!getCookie('jwt')) history.replace('../signin');
+	if (!getCookie('jwt')) {
+		localStorage.setItem('redirectURL', window.location.href);
+		history.replace('../signin');
+	}
 
 	const handleFetchProject = () => {
 		const getProjectInfoAPI = getProjectInfoAPICreator(projectId);

--- a/cocode/src/pages/index.js
+++ b/cocode/src/pages/index.js
@@ -4,5 +4,6 @@ import Project from './Project';
 import NotFound from './NotFound';
 import Live from './Live';
 import SignIn from './SignIn';
+import Empty from './Empty';
 
-export { Home, DashBoard, Project, NotFound, Live, SignIn };
+export { Home, DashBoard, Project, NotFound, Live, SignIn, Empty };


### PR DESCRIPTION
## 간단한 요약 설명
로그인을 해야하는 경우, 메인페이지로 이동하는 것이 아니라
원래의 url로 redirect 되어야 하기 때문에 해당 url을
로컬 스토리지에 저장하여 관리하는 로직을 구현하였습니다.
로그인 성공 시 로컬 스토리지에 저장되어있던 원래 url로
리다이렉트 시켜주는 페이지를 구현했습니다.

## 관련 이슈
* close #303
* close #304