### PR TITLE
HotFix for 1.3.0 in Coconut

### DIFF
--- a/coconut/src/bundler/pathParser.js
+++ b/coconut/src/bundler/pathParser.js
@@ -1,3 +1,4 @@
+/* eslint no-restricted-globals: 0 */
 import { pathStack } from './global';
 import path from 'path';
 

--- a/coconut/src/bundler/require.js
+++ b/coconut/src/bundler/require.js
@@ -1,3 +1,4 @@
+/* eslint no-restricted-globals: 0 */
 import { pathStack } from './global';
 import { pathParser } from './pathParser';
 import { transformCode } from './core';

--- a/coconut/src/worker/build.worker.js
+++ b/coconut/src/worker/build.worker.js
@@ -1,3 +1,4 @@
+/* eslint no-restricted-globals: 0 */
 import * as bundler from 'bundler';
 
 self.process = {};


### PR DESCRIPTION
## 간단한 요약 설명
배포 시 react app이 제대로 빌드 되지 않아 파일이 생성되지 않던 심각한 버그가 있었습니다.
검색을 통해 알아보니 worker 파일에서 self를 사용하면서 발생하는 에러였습니다.
/* eslint no-restricted-globals: 0 */ 설정을 self를 사용하는 파일에 추가하여 해결했습니다.